### PR TITLE
RONDB-828: Trigger rolling restarts when config.ini changes

### DIFF
--- a/templates/mgmd.yaml
+++ b/templates/mgmd.yaml
@@ -30,6 +30,8 @@ spec:
       # Used to apply labels to all pods created by the Deployment
       labels:
         rondbService: {{ include "rondb.labels.rondbService.mgmd" $ }}
+      annotations:
+        configIniHash: {{ include "rondb.configIniHash" $ }}
     spec:
 {{- include "rondb.imagePullSecrets" . | indent 6 }}
 {{- include "rondb.nodeSelector" (dict "nodeSelector" .Values.nodeSelector.mgmd) | indent 6 }}

--- a/templates/mysqlds/binlog_servers.yaml
+++ b/templates/mysqlds/binlog_servers.yaml
@@ -35,6 +35,8 @@ spec:
       # Used to apply labels to all pods created by the Deployment
       labels:
         rondbService: {{ include "rondb.labels.rondbService.binlog-servers" $ }}
+      annotations:
+        configIniHash: {{ include "rondb.configIniHash" $ }}
     spec:
 {{- include "rondb.imagePullSecrets" . | indent 6 }}
       affinity:

--- a/templates/mysqlds/mysqld.yaml
+++ b/templates/mysqlds/mysqld.yaml
@@ -22,6 +22,8 @@ spec:
       # Used to apply labels to all pods created by the Deployment
       labels:
         rondbService: {{ include "rondb.labels.rondbService.mysqld" $ }}
+      annotations:
+        configIniHash: {{ include "rondb.configIniHash" $ }}
     spec:
 {{- include "rondb.imagePullSecrets" . | indent 6 }}
 {{- include "rondb.nodeSelector" (dict "nodeSelector" $.Values.nodeSelector.mysqld) | indent 6 }}

--- a/templates/mysqlds/replica_appliers.yaml
+++ b/templates/mysqlds/replica_appliers.yaml
@@ -35,6 +35,8 @@ spec:
       # Used to apply labels to all pods created by the Deployment
       labels:
         rondbService: {{ include "rondb.labels.rondbService.replica-appliers" $ }}
+      annotations:
+        configIniHash: {{ include "rondb.configIniHash" $ }}
     spec:
 {{- include "rondb.imagePullSecrets" . | indent 6 }}
       serviceAccountName: {{ include "rondb.mysqldServiceAccountName" . }}

--- a/templates/ndbd.yaml
+++ b/templates/ndbd.yaml
@@ -89,6 +89,7 @@ spec:
         nodeGroup: {{ $nodeGroup | quote }}
       # This is an easy way to restart data nodes without changing specs.
       annotations:
+        configIniHash: {{ include "rondb.configIniHash" $ }}
 {{- range $k, $v := $.Values.meta.ndbmtd.statefulSet.podAnnotations }}
         {{ $k | quote }}: {{ $v | quote }}
 {{- end }}

--- a/templates/rdrs.yaml
+++ b/templates/rdrs.yaml
@@ -18,6 +18,8 @@ spec:
       # Used to apply labels to all pods created by the Deployment
       labels:
         rondbService: {{ include "rondb.labels.rondbService.rdrs" $ }}
+      annotations:
+        configIniHash: {{ include "rondb.configIniHash" $ }}
     spec:
 {{- include "rondb.imagePullSecrets" . | indent 6 }}
 {{- include "rondb.nodeSelector" (dict "nodeSelector" $.Values.nodeSelector.rdrs) | indent 6 }}

--- a/templates/shared_templates/_helpers.tpl
+++ b/templates/shared_templates/_helpers.tpl
@@ -228,3 +228,8 @@ spec:
 ---
 {{ end }}
 {{- end }}
+
+# This is an easy way to trigger rolling restarts of all RonDB Pods
+{{- define "rondb.configIniHash" -}}
+{{ mustRegexReplaceAll "NodeActive *=.*" (tpl ($.Files.Get "files/configs/config.ini") $) "" | sha256sum }}
+{{- end -}}


### PR DESCRIPTION
https://hopsworks.atlassian.net/browse/RONDB-828

This will trigger rolling updates of all Stateful Sets at the same time (instead of one by one). However, the MGMd should be up first anyways. And each Stateful Set will restart one Pod at a time.