### PR TITLE
RONDB-828: Append; Always initial start MGMds

### DIFF
--- a/files/scripts/mgmds.sh
+++ b/files/scripts/mgmds.sh
@@ -6,29 +6,10 @@
 # It is essentially the config.ini including all changes that were applied via the
 # management client (ndb_mgm).
 
-INITIAL_ARG=
-CONFIG_DB_DIR={{ include "rondb.dataDir" $ }}/mgmd
-FOUND_FILES=$(find "$CONFIG_DB_DIR" -type f -name "*config.bin.*")
-NUM_FOUND=$(echo "$FOUND_FILES" | grep -c .)
-if [ "$NUM_FOUND" -lt 1 ]; then
-    echo "No configuration database available. Doing an initial start."
-    INITIAL_ARG="--initial"
-
-    BASE_DIR={{ include "rondb.dataDir" $ }}
-    RONDB_VOLUME=${BASE_DIR}/default_storage
-    for dir in log mgmd
-    do
-        rm -rf ${BASE_DIR}/${dir}
-        mkdir -p ${RONDB_VOLUME}/${dir}
-        ln -s ${RONDB_VOLUME}/${dir} ${BASE_DIR}/${dir}
-    done
-
-else
-    echo "A configuration database was found. Not running an initial start."
-fi
-
-ndb_mgmd $INITIAL_ARG \
+# We're always doing an initial start so that changes in the config.ini are applied
+# Even if the main container starts, it will have the newest config.ini mounted to it.
+ndb_mgmd --initial \
     --nodaemon \
     --ndb-nodeid=65 \
     -f "$RONDB_DATA_DIR/config.ini" \
-    --configdir="$CONFIG_DB_DIR"
+    --configdir="{{ include "rondb.dataDir" $ }}/mgmd"

--- a/files/scripts/ndbmtds.sh
+++ b/files/scripts/ndbmtds.sh
@@ -36,8 +36,11 @@ handle_sigterm() {
 
     # Even when not deactivating nodes, having too many nodes die at once can cause
     # the arbitration to kill the cluster. The living node will not be able to form
-    # a majority. HOWEVER, since we are using a RollingUpdate strategy, only one
-    # data node (per node group) will be killed at once.
+    # a majority. Usually, since we are using a RollingUpdate strategy, only one
+    # data node (per node group) will be killed at once. It does however become an issue
+    # if e.g. the number of replicas is changed from 3 to 1. Then replica 3 and 2 are
+    # killed simultaneously. When needing to debug such situtations it can be helpful
+    # to restart all data nodes at once.
 
     while ! ndb_mgm --ndb-connectstring="$MGM_CONNECTSTRING" --connect-retries=1 -e "$NODE_ID deactivate"; do
         echo "[K8s Entrypoint ndbmtd] Deactivated node id $NODE_ID via MGM client was unsuccessful. Retrying..." >&2

--- a/templates/mgmd.yaml
+++ b/templates/mgmd.yaml
@@ -89,8 +89,9 @@ spec:
         - name: mgmd-configs
           mountPath: {{ include "rondb.dataDir" $ }}/config.ini
           subPath: config.ini
+        # We're not persisting the configuration database
         - name: rondb-mgmd
-          mountPath: {{ include "rondb.dataDir" $ }}/default_storage
+          mountPath: {{ include "rondb.dataDir" $ }}/log
       volumes:
       - name: mgmd-configs
         configMap:

--- a/values.schema.json
+++ b/values.schema.json
@@ -852,6 +852,7 @@
             "properties": {
                 "activeDataReplicas": {
                     "type": "integer",
+                    "description": "How many replicas each node group has. When descreasing this value, try going down by 1 at a time. Too many nodes leaving at once can cause issues with leader elections.",
                     "minimum": 1,
                     "maximum": 3,
                     "default": 2


### PR DESCRIPTION
https://hopsworks.atlassian.net/browse/RONDB-828

For upgrading clusters this will be slightly awkward, since the existing volume is now mounted on a different path. Most importantly this means that the cluster.log will be interrupted and continued at its new file path `srv/hops/mysql-cluster/log/cluster.log` (the old one will still exist under `srv/hops/mysql-cluster/log/log/cluster.log`).