### PR TITLE
HOPSWORKS-2182: Wrong use of ArbitrationRank

### DIFF
--- a/files/configs/config.ini
+++ b/files/configs/config.ini
@@ -268,7 +268,7 @@ LocationDomainId=0
 HostName={{ include "rondb.mgmdHostname" . }}
 PortNumber=1186
 NodeActive=1
-ArbitrationRank=2
+ArbitrationRank=1
 
 {{ $mysqldStartNodeId := 67 -}}
 {{/*

--- a/templates/shared_templates/config.ini.tpl
+++ b/templates/shared_templates/config.ini.tpl
@@ -12,7 +12,7 @@ LocationDomainId=0
 NodeId={{ .nodeId }}
 LocationDomainId=0
 NodeActive={{ .isActive }}
-ArbitrationRank=1
+ArbitrationRank=2
 HostName={{ .hostname }}
 {{- end }}
 
@@ -21,6 +21,6 @@ HostName={{ .hostname }}
 NodeId={{ .nodeId }}
 LocationDomainId=0
 NodeActive={{ .isActive }}
-ArbitrationRank=1
+ArbitrationRank=2
 HostName={{ .hostname }}
 {{- end }}


### PR DESCRIPTION
ArbitrationRank=1 is the highest priority, this should be used by the RonDB Management server and API nodes and MySQL Servers should use ArbitrationRank=2 which is lower priority.