### PR TITLE
RONDB-958: Add ActivateRateLimits to Helm config

### DIFF
--- a/files/configs/config.ini
+++ b/files/configs/config.ini
@@ -180,6 +180,8 @@ TransactionDeadlockDetectionTimeout={{ .Values.rondbConfig.TransactionDeadlockDe
 HeartbeatIntervalDbApi={{ .Values.rondbConfig.HeartbeatIntervalDbApi | default 1500 }}
 HeartbeatIntervalDbDb={{ .Values.rondbConfig.HeartbeatIntervalDbDb | default 5000 }}
 
+ActivateRateLimits={{ .Values.rondbConfig.ActivateRateLimits | default 0 }}
+
 #0: Disables locking. This is the default value.
 #1: Performs the lock after allocating memory for the process.
 #2: Performs the lock before memory for the process is allocated.

--- a/values.schema.json
+++ b/values.schema.json
@@ -1306,6 +1306,13 @@
                     "description": "DiskPageBufferMemory are used by disk columns. This is the page cache that contains disk pages when they are in memory. By default it is not defined.",
                     "default": null
                 },
+                "ActivateRateLimits": {
+                    "type": "integer",
+                    "description": "Activate rate limits handling",
+                    "minimum": 0,
+                    "maximum": 1,
+                    "default": 0
+                },
                 "TransactionInactiveTimeout": {
                     "type": "integer",
                     "description": "Milliseconds that application waits before executing another part of transaction",

--- a/values.yaml
+++ b/values.yaml
@@ -302,6 +302,7 @@ restoreFromBackup:
       name: aws-credentials
     serverSideEncryption: null
 rondbConfig:
+  ActivateRateLimits: 0
   DiskPageBufferMemory: null
   EmptyApiSlots: 8
   HeartbeatIntervalDbApi: 5000


### PR DESCRIPTION
Rate Limits are only active if configured to be so since it is not supposed to be a feature for
all clusters, only for multi-tenant clusters. Thus rondb-helm need a config variable for this.