### PR TITLE
[HWORKS-2002] Add in-place backup restore for existing clusters

### DIFF
--- a/.github/test_deploy_stability.sh
+++ b/.github/test_deploy_stability.sh
@@ -17,10 +17,20 @@ while true; do
         egrep -v "Succeeded" |
         grep -e POD -e POD_PHASE -e "Pending" -e "false")
 
+    # Check that all StatefulSets have their desired replica count.
+    # This catches scenarios where a StatefulSet has 0 pods (e.g. FailedCreate),
+    # which the pod readiness check above would vacuously pass.
+    STS_NOT_READY=$(kubectl get statefulsets -n $K8S_NAMESPACE --no-headers 2>/dev/null | awk '{split($2,a,"/"); if (a[1] != a[2]) print $0}')
+
+    PODS_READY=true
     # lt 2 because of header (keep for readability)
-    if [ $(echo "$NUM_NOT_READY" | wc -l) -lt 2 ]; then
+    if [ $(echo "$NUM_NOT_READY" | wc -l) -ge 2 ]; then
+        PODS_READY=false
+    fi
+
+    if $PODS_READY && [ -z "$STS_NOT_READY" ]; then
         OK_SECONDS=$((OK_SECONDS + SLEEP_SECONDS))
-        echo "All pods have been ready for $OK_SECONDS seconds now"
+        echo "All pods and StatefulSets have been ready for $OK_SECONDS seconds now"
         OK_MINUTES=$((OK_SECONDS / 60))
         if [ $OK_MINUTES -ge $MIN_STABLE_MINUTES ]; then
             echo "The cluster seems stable"
@@ -46,11 +56,25 @@ while true; do
         echo && kubectl top pod -n $K8S_NAMESPACE && echo && echo
         echo && kubectl get node && echo
         echo && kubectl top node && echo
+        if [ -n "$STS_NOT_READY" ]; then
+            echo
+            echo "####################################################"
+            echo "StatefulSets not at desired replica count"
+            echo "####################################################"
+            kubectl get statefulsets -n $K8S_NAMESPACE && echo
+            kubectl describe statefulsets -n $K8S_NAMESPACE && echo
+        fi
         SKIP=0
     else
         SKIP=$((SKIP + 1))
     fi
 
-    echo "Some Pods are pending or not ready yet" && echo
-    echo "$NUM_NOT_READY" && echo
+    if ! $PODS_READY; then
+        echo "Some Pods are pending or not ready yet" && echo
+        echo "$NUM_NOT_READY" && echo
+    fi
+    if [ -n "$STS_NOT_READY" ]; then
+        echo "Some StatefulSets don't have all replicas ready:" && echo
+        echo "$STS_NOT_READY" && echo
+    fi
 done

--- a/Chart.yaml
+++ b/Chart.yaml
@@ -6,7 +6,7 @@ name: rondb
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 26.02.2
+version: 26.02.3
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.

--- a/files/scripts/backups/native_download.sh
+++ b/files/scripts/backups/native_download.sh
@@ -8,12 +8,24 @@ set -e
 
 {{ include "rondb.nodeId" $ }}
 
+{{- if not (include "rondb.restoreFromBackup.isInPlace" $) }}
+# Normal restore: skip if data already exists
 # This is the first file that is read by the ndbmtd
 FIRST_FILE_READ=$FILE_SYSTEM_PATH/ndb_${NODE_ID}_fs/D1/DBDIH/P0.sysfile
 if [ -f "$FIRST_FILE_READ" ]; then
     echo "The data node has started before, no need to download a backup"
     exit 0
 fi
+{{- else }}
+# In-place restore: use marker file to track download completion
+# (backup dir may be deleted after restore, so we can't rely on its presence)
+DOWNLOAD_MARKER=/home/hopsworks/data/backup_downloaded_${BACKUP_ID}
+if [ -f "$DOWNLOAD_MARKER" ]; then
+    echo "In-place restore: backup already downloaded (marker found), skipping"
+    exit 0
+fi
+echo "In-place restore mode: downloading backup"
+{{- end }}
 
 {{ include "rondb.mapNewNodesToBackedUpNodes" . }}
 
@@ -36,6 +48,10 @@ done
 if [[ -d $LOCAL_BACKUP_DIR ]]; then
     echo "Successfully copied over all relevant native backups"
     ls -la $LOCAL_BACKUP_DIR
+{{- if include "rondb.restoreFromBackup.isInPlace" $ }}
+    # Mark download as complete for this backup ID
+    touch /home/hopsworks/data/backup_downloaded_${BACKUP_ID}
+{{- end }}
 else
     echo "No native backup has been downloaded by this node"
 fi

--- a/files/scripts/ndbmtds.sh
+++ b/files/scripts/ndbmtds.sh
@@ -107,14 +107,38 @@ if [ -d "$LOG_DIR" ]; then
   fi
 fi
 
-INITIAL_START=
 # This is the first file that is read by the ndbmtd
 # WARNING: This env var needs to be aware of symlinks created here
 FIRST_FILE_READ=$FILE_SYSTEM_PATH/ndb_${NODE_ID}_fs/D1/DBDIH/P0.sysfile
-if [ ! -f "$FIRST_FILE_READ" ]
-then
+
+# Only set marker path if in-place restore mode (env vars set by ndbd.yaml).
+# The marker is stored at the PVC root (RONDB_VOLUME) instead of inside ndb_data
+# because ndb_data is wiped/recreated when starting with --initial. Placing the
+# marker at the volume root ensures it survives an initial start and can be used
+# to decide whether --initial should be run again for a given INPLACE_BACKUP_ID.
+INITIAL_DONE_MARKER=""
+if [ "${FORCE_INITIAL_START:-}" = "true" ] && [ -n "${INPLACE_BACKUP_ID:-}" ]; then
+    INITIAL_DONE_MARKER="${RONDB_VOLUME}/inplace_restore_done_${INPLACE_BACKUP_ID}"
+fi
+
+# Determine if --initial should be used
+INITIAL_START=
+if [ -n "$INITIAL_DONE_MARKER" ]; then
+    # In-place restore mode - check BOTH marker AND P0.sysfile for robustness
+    if [ ! -f "$INITIAL_DONE_MARKER" ]; then
+        echo "[K8s Entrypoint ndbmtd] In-place restore (backup $INPLACE_BACKUP_ID): first start, using --initial"
+        INITIAL_START="--initial"
+        touch "$INITIAL_DONE_MARKER"
+    elif [ ! -f "$FIRST_FILE_READ" ]; then
+        # Marker exists BUT no P0.sysfile = previous --initial was interrupted
+        echo "[K8s Entrypoint ndbmtd] In-place restore: previous --initial was interrupted, retrying"
+        INITIAL_START="--initial"
+    else
+        echo "[K8s Entrypoint ndbmtd] In-place restore: already initialized, skipping --initial"
+    fi
+elif [ ! -f "$FIRST_FILE_READ" ]; then
     echo "[K8s Entrypoint ndbmtd] The file $FIRST_FILE_READ does not exist - we'll do an initial start here"
-    INITIAL_START="--initial"    
+    INITIAL_START="--initial"
 else
     echo "[K8s Entrypoint ndbmtd] The file $FIRST_FILE_READ exists - we have started the ndbmtds here before. No initial start is needed."
 fi

--- a/templates/backups/inplace_restore.yaml
+++ b/templates/backups/inplace_restore.yaml
@@ -1,0 +1,263 @@
+# Copyright (c) 2024-2026 Hopsworks AB. All rights reserved.
+
+{{- if include "rondb.restoreFromBackup.isInPlace" . }}
+{{- if include "rondb.canUseLookupFunc" (dict "global" .Values.global) -}}
+  {{- $restoreJobName := include "rondb.restoreNativeBackupJobname" . -}}
+  {{- $setupJobName := include "rondb.mysqldSetupJobName" . -}}
+  {{- $restoreJob := lookup "batch/v1" "Job" .Release.Namespace $restoreJobName -}}
+  {{- $setupJob := lookup "batch/v1" "Job" .Release.Namespace $setupJobName -}}
+  {{- if and $restoreJob $restoreJob.status (eq (int (default 0 $restoreJob.status.succeeded)) 1) -}}
+    {{- fail (printf "\n\nERROR: In-place restore already completed!\nThe restore job '%s' has already succeeded.\nAborting to prevent accidental data loss.\n\nTo restore again, first delete the completed jobs:\n  kubectl delete job %s %s -n %s\n\nTo return to normal upgrades, disable in-place restore and clear the backup ID:\n  --set restoreFromBackup.inPlace=false --set restoreFromBackup.forceDataClear=false --set-string restoreFromBackup.backupId=\nOr globally:\n  --set global._hopsworks.restoreFromBackup.inPlace=false --set global._hopsworks.restoreFromBackup.forceDataClear=false --set-string global._hopsworks.restoreFromBackup.backupId=\n" $restoreJobName $restoreJobName $setupJobName .Release.Namespace) -}}
+  {{- end -}}
+  {{- if and $setupJob $setupJob.status (eq (int (default 0 $setupJob.status.succeeded)) 1) -}}
+    {{- fail (printf "\n\nERROR: In-place restore already completed!\nThe setup mysqld job '%s' has already succeeded.\nAborting to prevent accidental data loss.\n\nTo restore again, first delete the completed jobs:\n  kubectl delete job %s %s -n %s\n\nTo return to normal upgrades, disable in-place restore and clear the backup ID:\n  --set restoreFromBackup.inPlace=false --set restoreFromBackup.forceDataClear=false --set-string restoreFromBackup.backupId=\nOr globally:\n  --set global._hopsworks.restoreFromBackup.inPlace=false --set global._hopsworks.restoreFromBackup.forceDataClear=false --set-string global._hopsworks.restoreFromBackup.backupId=\n" $setupJobName $restoreJobName $setupJobName .Release.Namespace) -}}
+  {{- end -}}
+{{- end }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: rondb-inplace-restore-sa
+  namespace: {{ .Release.Namespace }}
+  annotations:
+    "helm.sh/hook": pre-upgrade
+    "helm.sh/hook-weight": "-10"
+    "helm.sh/hook-delete-policy": before-hook-creation
+{{ include "rondb.serviceAccountAnnotations" $ | indent 2 }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: rondb-inplace-restore-role
+  namespace: {{ .Release.Namespace }}
+  annotations:
+    "helm.sh/hook": pre-upgrade
+    "helm.sh/hook-weight": "-10"
+    "helm.sh/hook-delete-policy": before-hook-creation
+rules:
+  - apiGroups: ["apps"]
+    resources: ["statefulsets", "statefulsets/scale"]
+    verbs: ["get", "list", "patch", "update"]
+    resourceNames:
+      - {{ .Values.meta.mysqld.statefulSet.name }}
+      - {{ .Values.meta.rdrs.statefulSet.name }}
+      - {{ .Values.meta.binlogServers.statefulSet.name }}
+      - {{ .Values.meta.replicaAppliers.statefulSet.name }}
+      {{- range $g := until (int .Values.clusterSize.numNodeGroups) }}
+      - node-group-{{ $g }}
+      {{- end }}
+  - apiGroups: ["autoscaling"]
+    resources: ["horizontalpodautoscalers"]
+    verbs: ["delete"]
+    resourceNames:
+      - {{ .Values.meta.mysqld.statefulSet.name }}
+  - apiGroups: ["batch"]
+    resources: ["jobs"]
+    verbs: ["get"]
+    resourceNames:
+      - {{ include "rondb.restoreNativeBackupJobname" . }}
+      - {{ include "rondb.mysqldSetupJobName" . }}
+  # Pods: need list/watch for kubectl wait with label selectors (can't restrict by resourceNames)
+  - apiGroups: [""]
+    resources: ["pods"]
+    verbs: ["get", "list", "watch"]
+  # Pods/exec: only needed for data node pods to clean markers
+  - apiGroups: [""]
+    resources: ["pods/exec"]
+    verbs: ["create"]
+    resourceNames:
+      {{- range $g := until (int .Values.clusterSize.numNodeGroups) }}
+      {{- range $r := until (int $.Values.clusterSize.activeDataReplicas) }}
+      - node-group-{{ $g }}-{{ $r }}
+      {{- end }}
+      {{- end }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: rondb-inplace-restore-rb
+  namespace: {{ .Release.Namespace }}
+  annotations:
+    "helm.sh/hook": pre-upgrade
+    "helm.sh/hook-weight": "-10"
+    "helm.sh/hook-delete-policy": before-hook-creation
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: rondb-inplace-restore-role
+subjects:
+  - kind: ServiceAccount
+    name: rondb-inplace-restore-sa
+    namespace: {{ .Release.Namespace }}
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: rondb-inplace-restore-shutdown
+  namespace: {{ .Release.Namespace }}
+  annotations:
+    "helm.sh/hook": pre-upgrade
+    "helm.sh/hook-weight": "-5"
+    "helm.sh/hook-delete-policy": before-hook-creation
+spec:
+  backoffLimit: 0
+  template:
+    metadata:
+      labels:
+        rondbService: inplace-restore
+    spec:
+      restartPolicy: Never
+      serviceAccountName: rondb-inplace-restore-sa
+{{- include "rondb.PodSecurityContext" $ | indent 6 }}
+{{- include "rondb.imagePullSecrets" . | indent 6 }}
+{{- include "rondb.nodeSelector" (dict "nodeSelector" $.Values.nodeSelector.backup) | indent 6 }}
+{{- include "rondb.tolerations" (dict "tolerations" $.Values.tolerations.backup) | indent 6 }}
+{{- if .Values.priorityClass }}
+      priorityClassName: {{ .Values.priorityClass | quote }}
+{{- end }}
+      containers:
+      - name: shutdown-cluster
+        image: {{ include "image_address" (dict "image" $.Values.images.toolbox) }}
+        imagePullPolicy: {{ $.Values.imagePullPolicy }}
+{{- include "rondb.ContainerSecurityContext" $ | indent 8 }}
+        command:
+        - /bin/bash
+        - -c
+        - |
+          set -e
+          WAIT_TIMEOUT="600s"
+
+          # Check if this backup was already restored successfully
+          # This prevents accidental data loss if user forgets to unset inPlace/forceDataClear
+          RESTORE_STATUS=$(kubectl get job "$RESTORE_JOB_NAME" -n $NAMESPACE -o jsonpath='{.status.succeeded}' 2>/dev/null || echo "")
+          SETUP_MYSQLD_STATUS=$(kubectl get job "$SETUP_MYSQLD_JOB_NAME" -n $NAMESPACE -o jsonpath='{.status.succeeded}' 2>/dev/null || echo "")
+          if [ "$RESTORE_STATUS" = "1" ] || [ "$SETUP_MYSQLD_STATUS" = "1" ]; then
+              echo "============================================================" >&2
+              echo "ERROR: In-place restore already completed!" >&2
+              echo "============================================================" >&2
+              echo "" >&2
+              [ "$RESTORE_STATUS" = "1" ] && echo "The restore job '$RESTORE_JOB_NAME' has already succeeded." >&2
+              [ "$SETUP_MYSQLD_STATUS" = "1" ] && echo "The setup mysqld job '$SETUP_MYSQLD_JOB_NAME' has already succeeded." >&2
+              echo "Aborting to prevent accidental data loss." >&2
+              echo "" >&2
+              echo "If you intended to restore again, first delete the completed jobs:" >&2
+              echo "  kubectl delete job $RESTORE_JOB_NAME -n $NAMESPACE" >&2
+              echo "  kubectl delete job $SETUP_MYSQLD_JOB_NAME -n $NAMESPACE" >&2
+              echo "" >&2
+              echo "To return to normal upgrades, disable in-place restore and clear the backup ID:" >&2
+              echo "  --set restoreFromBackup.inPlace=false --set restoreFromBackup.forceDataClear=false --set-string restoreFromBackup.backupId=" >&2
+              echo "Or globally:" >&2
+              echo "  --set global._hopsworks.restoreFromBackup.inPlace=false --set global._hopsworks.restoreFromBackup.forceDataClear=false --set-string global._hopsworks.restoreFromBackup.backupId=" >&2
+              echo "============================================================" >&2
+              exit 1
+          fi
+
+          echo "=== In-Place Restore: Shutting down cluster ==="
+
+          # 1. Delete old markers while pods are running
+          # Note: ndbmtd container mounts PVC at /srv/hops/mysql-cluster/default_storage
+          echo "Deleting old in-place restore markers..."
+          for ((g = 0; g < $NUM_NODE_GROUPS; g++)); do
+              for ((r = 0; r < $ACTIVE_DATA_REPLICAS; r++)); do
+                  POD_NAME="node-group-$g-$r"
+                  echo "Cleaning markers on $POD_NAME"
+                  kubectl exec -n $NAMESPACE "$POD_NAME" -c ndbmtd -- \
+                      /bin/bash -c 'rm -f /srv/hops/mysql-cluster/default_storage/inplace_restore_done_* /srv/hops/mysql-cluster/default_storage/backup_downloaded_* 2>/dev/null || true' || true
+              done
+          done
+
+          # 2. Delete HPA to prevent race condition (it will be recreated by main upgrade)
+          echo "Deleting MySQLd HPA..."
+          kubectl delete hpa $MYSQLD_STS_NAME -n $NAMESPACE --ignore-not-found=true
+
+          # 3. Scale down RDRS (if enabled)
+          if [ "$MIN_NUM_RDRS" -gt 0 ]; then
+              echo "Scaling down RDRS..."
+              kubectl scale statefulset/$RDRS_STS_NAME -n $NAMESPACE --replicas=0
+          fi
+
+          # 4. Scale down MySQLd
+          echo "Scaling down MySQLd..."
+          kubectl scale statefulset/$MYSQLD_STS_NAME -n $NAMESPACE --replicas=0
+
+          # 5. Scale down binlog servers (if enabled)
+          if [ "$BINLOG_ENABLED" = "true" ]; then
+              echo "Scaling down binlog servers..."
+              kubectl scale statefulset/$BINLOG_STS_NAME -n $NAMESPACE --replicas=0 || true
+          fi
+
+          # 6. Scale down replica appliers (if enabled)
+          if [ "$REPLICA_APPLIER_ENABLED" = "true" ]; then
+              echo "Scaling down replica appliers..."
+              kubectl scale statefulset/$REPLICA_APPLIER_STS_NAME -n $NAMESPACE --replicas=0 || true
+          fi
+
+          # 7. Scale down ALL data node StatefulSets (LAST - after API nodes)
+          echo "Scaling down data nodes..."
+          for ((g = 0; g < $NUM_NODE_GROUPS; g++)); do
+              kubectl scale statefulset/node-group-$g -n $NAMESPACE --replicas=0
+          done
+
+          # 8. Wait for all pods to terminate
+          # Fail the hook if any pods remain stuck (e.g., finalizers, long termination).
+          # Proceeding with an upgrade/restore while pods are still running risks
+          # data corruption or a hung upgrade.
+          #
+          # Each wait is guarded by a pod-existence check because
+          # `kubectl wait --for=delete -l ...` fails with "no matching resources found"
+          # when no pods match the selector (kubectl < 1.28). Since services are
+          # scaled down before data nodes, their pods may already be gone by the
+          # time we reach their wait.
+          wait_for_pod_deletion() {
+              local label=$1
+              local description=$2
+              if kubectl get pod -l "$label" -n $NAMESPACE --no-headers 2>/dev/null | grep -q .; then
+                  echo "Waiting for $description pods to terminate..."
+                  kubectl wait --for=delete pod -l "$label" -n $NAMESPACE --timeout=$WAIT_TIMEOUT
+              else
+                  echo "No $description pods found, skipping wait."
+              fi
+          }
+
+          wait_for_pod_deletion "rondbService=ndbmtd" "data node"
+          wait_for_pod_deletion "rondbService=mysqld" "MySQLd"
+          if [ "$MIN_NUM_RDRS" -gt 0 ]; then
+              wait_for_pod_deletion "rondbService=rdrs" "RDRS"
+          fi
+          if [ "$BINLOG_ENABLED" = "true" ]; then
+              wait_for_pod_deletion "rondbService=binlog-server" "binlog server"
+          fi
+          if [ "$REPLICA_APPLIER_ENABLED" = "true" ]; then
+              wait_for_pod_deletion "rondbService=replica-applier" "replica applier"
+          fi
+
+          echo "=== Cluster shutdown complete ==="
+        env:
+        - name: NAMESPACE
+          value: {{ .Release.Namespace | quote }}
+        - name: NUM_NODE_GROUPS
+          value: {{ .Values.clusterSize.numNodeGroups | quote }}
+        - name: ACTIVE_DATA_REPLICAS
+          value: {{ .Values.clusterSize.activeDataReplicas | quote }}
+        - name: MYSQLD_STS_NAME
+          value: {{ .Values.meta.mysqld.statefulSet.name | quote }}
+        - name: RDRS_STS_NAME
+          value: {{ .Values.meta.rdrs.statefulSet.name | quote }}
+        - name: BINLOG_STS_NAME
+          value: {{ .Values.meta.binlogServers.statefulSet.name | quote }}
+        - name: MIN_NUM_RDRS
+          value: {{ .Values.clusterSize.minNumRdrs | quote }}
+        - name: BINLOG_ENABLED
+          value: {{ if .Values.globalReplication.primary.enabled }}"true"{{ else }}"false"{{ end }}
+        - name: REPLICA_APPLIER_ENABLED
+          value: {{ if .Values.globalReplication.secondary.enabled }}"true"{{ else }}"false"{{ end }}
+        - name: REPLICA_APPLIER_STS_NAME
+          value: {{ .Values.meta.replicaAppliers.statefulSet.name | quote }}
+        - name: RESTORE_JOB_NAME
+          value: {{ include "rondb.restoreNativeBackupJobname" . | quote }}
+        - name: SETUP_MYSQLD_JOB_NAME
+          value: {{ include "rondb.mysqldSetupJobName" . | quote }}
+        resources:
+          limits:
+            cpu: 0.5
+            memory: 200Mi
+{{- end }}

--- a/templates/backups/restore.yaml
+++ b/templates/backups/restore.yaml
@@ -98,6 +98,7 @@ spec:
       - name: restore-ndbmtd-metadata
         image: {{ include "image_address" (dict "image" $.Values.images.toolbox) }}
         imagePullPolicy: {{ $.Values.imagePullPolicy }}
+{{ include "rondb.ContainerSecurityContext" $ | indent 8 }}
         command:
         - /bin/bash
         - -c
@@ -154,6 +155,7 @@ spec:
       - name: restore-ndbmtd-data
         image: {{ include "image_address" (dict "image" $.Values.images.toolbox) }}
         imagePullPolicy: {{ $.Values.imagePullPolicy }}
+{{ include "rondb.ContainerSecurityContext" $ | indent 8 }}
         command:
         - /bin/bash
         - -c
@@ -231,6 +233,7 @@ spec:
       - name: restore-backup-indexes
         image: {{ include "image_address" (dict "image" $.Values.images.toolbox) }}
         imagePullPolicy: {{ $.Values.imagePullPolicy }}
+{{ include "rondb.ContainerSecurityContext" $ | indent 8 }}
         command:
         - /bin/bash
         - -c
@@ -269,6 +272,7 @@ spec:
       - name: remove-native-backup
         image: {{ include "image_address" (dict "image" $.Values.images.toolbox) }}
         imagePullPolicy: {{ $.Values.imagePullPolicy }}
+{{ include "rondb.ContainerSecurityContext" $ | indent 8 }}
         command:
         - /bin/bash
         - -c

--- a/templates/mysqlds/_helpers.tpl
+++ b/templates/mysqlds/_helpers.tpl
@@ -16,6 +16,7 @@
 - name: wait-one-binlog-server
   image: {{ include "image_address" (dict "image" $.Values.images.rondb) }}
   imagePullPolicy: {{ $.Values.imagePullPolicy }}
+{{ include "rondb.ContainerSecurityContext" $ | indent 2 }}
   command:
   - /bin/bash
   - -c
@@ -57,7 +58,7 @@
 {{- end }}
 
 {{- define "rondb.container.waitSingleSetup" -}}
-{{- if include "rondb.isInstall" . }}
+{{- if or (include "rondb.isInstall" .) (and (include "rondb.isUpgrade" .) (include "rondb.restoreFromBackup.isInPlace" .)) }}
 - name: wait-single-setup-job
   image: {{ include "image_address" (dict "image" $.Values.images.toolbox) }}
   imagePullPolicy: {{ $.Values.imagePullPolicy }}

--- a/templates/mysqlds/_vars.tpl
+++ b/templates/mysqlds/_vars.tpl
@@ -47,7 +47,11 @@ helm-user-supplied.sql
 
 # A successful Pod can be removed; don't remove the successful Job itself though
 {{- define "rondb.mysqldSetupJobName" -}}
+{{- if include "rondb.restoreFromBackup.backupId" . -}}
+setup-mysqld-dont-remove-{{ include "rondb.restoreFromBackup.backupId" . }}
+{{- else -}}
 setup-mysqld-dont-remove
+{{- end -}}
 {{- end -}}
 
 {{- define "rondb.serviceAccount.restoreWatcher" -}}

--- a/templates/mysqlds/binlog_servers.yaml
+++ b/templates/mysqlds/binlog_servers.yaml
@@ -69,12 +69,17 @@ spec:
       priorityClassName: {{ .Values.priorityClass | quote }}
 {{- end  }}
 {{- if include "rondb.restoreFromBackup.backupId" . }}
-      # We need to wait for the restore Job
       serviceAccountName: {{ include "rondb.serviceAccount.restoreWatcher" . }}
+{{- else }}
+      # Explicitly set to 'default' so Helm's three-way merge updates the field
+      # value rather than trying to delete it (which fails for scalar fields in
+      # nested pod template specs, leaving a stale SA reference).
+      serviceAccountName: default
 {{- end }}
       initContainers:
       - name: mysqld-init-datadir
         image: {{ include "image_address" (dict "image" .Values.images.rondb) }}
+{{ include "rondb.ContainerSecurityContext" $ | indent 8 }}
         command:
         - /bin/bash
         - -c
@@ -140,6 +145,7 @@ spec:
       - name: binlog-server
         image: {{ include "image_address" (dict "image" .Values.images.rondb) }}
         imagePullPolicy: {{ $.Values.imagePullPolicy }}
+{{ include "rondb.ContainerSecurityContext" (dict "Values" $.Values "addSysNice" $.Values.meta.mysqld.addSysNiceCapability) | indent 8 }}
         command:
         - /bin/bash
         - -c
@@ -214,10 +220,6 @@ spec:
           failureThreshold: 4
           periodSeconds: 2
           timeoutSeconds: 2
-        securityContext:
-          capabilities:
-            add:
-              - SYS_NICE
         volumeMounts:
         # Only mount single file, otherwise entire directory becomes read-only
         - name: mysqld-configs

--- a/templates/mysqlds/mysqld.yaml
+++ b/templates/mysqlds/mysqld.yaml
@@ -245,7 +245,7 @@ spec:
 apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler
 metadata:
-  name: mysqlds
+  name: {{ .Values.meta.mysqld.statefulSet.name }}
   namespace: {{ .Release.Namespace }}
 spec:
   scaleTargetRef:

--- a/templates/mysqlds/replica_appliers.yaml
+++ b/templates/mysqlds/replica_appliers.yaml
@@ -69,6 +69,7 @@ spec:
       initContainers:
       - name: mysqld-init-datadir
         image: {{ include "image_address" (dict "image" .Values.images.rondb) }}
+{{ include "rondb.ContainerSecurityContext" $ | indent 8 }}
         command:
         - /bin/bash
         - -c
@@ -117,6 +118,7 @@ spec:
       - name: mysqld
         image: {{ include "image_address" (dict "image" .Values.images.rondb) }}
         imagePullPolicy: {{ $.Values.imagePullPolicy }}
+{{ include "rondb.ContainerSecurityContext" (dict "Values" $.Values "addSysNice" $.Values.meta.mysqld.addSysNiceCapability) | indent 8 }}
         command:
         - /bin/bash
         - -c
@@ -165,10 +167,6 @@ spec:
               fieldRef:
                 fieldPath: metadata.name
 {{ include "rondb.mysqld.probes" (dict "tls" $.Values.meta.replicaAppliers.statefulSet.endToEndTls) | indent 8 }}
-        securityContext:
-          capabilities:
-            add:
-              - SYS_NICE
         volumeMounts:
         # Only mount single file, otherwise entire directory becomes read-only
         - name: mysqld-configs
@@ -190,6 +188,7 @@ spec:
       - name: replica-applier-controller
         image: {{ include "image_address" (dict "image" .Values.images.rondb) }}
         imagePullPolicy: {{ $.Values.imagePullPolicy }}
+{{ include "rondb.ContainerSecurityContext" $ | indent 8 }}
         command:
         - /bin/bash
         - -c

--- a/templates/mysqlds/setup_job.yaml
+++ b/templates/mysqlds/setup_job.yaml
@@ -7,7 +7,7 @@
     scripts, if any are provided by the Helm user. The Job will wait for the
     native restore-backup Job to have completed, if the user has provided a backup ID.
 */}}
-{{- if include "rondb.isInstall" . }}
+{{- if or (include "rondb.isInstall" .) (include "rondb.restoreFromBackup.isInPlace" .) }}
 apiVersion: batch/v1
 kind: Job
 metadata:
@@ -37,6 +37,7 @@ spec:
       - name: download-mysql-metadata
         image: {{ include "image_address" (dict "image" $.Values.images.toolbox) }}
         imagePullPolicy: {{ $.Values.imagePullPolicy }}
+{{ include "rondb.ContainerSecurityContext" $ | indent 8 }}
         workingDir: /home/hopsworks
         command:
         - /bin/bash

--- a/templates/ndbd.yaml
+++ b/templates/ndbd.yaml
@@ -142,6 +142,7 @@ spec:
 {{- if include "rondb.restoreFromBackup.backupId" $ }}
       - name: download-backup-to-restore
         image: {{ include "image_address" (dict "image" $.Values.images.toolbox) }}
+{{ include "rondb.ContainerSecurityContext" $ | indent 8 }}
         # Setting resources in order to be in QoS class Guaranteed
         resources:
           limits:
@@ -261,6 +262,12 @@ spec:
                 fieldPath: metadata.name
           - name: FILE_SYSTEM_PATH
             value: {{ include "rondb.ndbmtd.fileSystemPath" $ }}
+{{- if include "rondb.restoreFromBackup.isInPlace" $ }}
+          - name: FORCE_INITIAL_START
+            value: "true"
+          - name: INPLACE_BACKUP_ID
+            value: {{ include "rondb.restoreFromBackup.backupId" $ | quote }}
+{{- end }}
         startupProbe:
           exec:
             command:

--- a/templates/rdrs.yaml
+++ b/templates/rdrs.yaml
@@ -209,7 +209,7 @@ spec:
 apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler
 metadata:
-  name: rdrs
+  name: {{ .Values.meta.rdrs.statefulSet.name }}
   namespace: {{ .Release.Namespace }}
 spec:
   scaleTargetRef:

--- a/templates/shared_templates/_helpers.tpl
+++ b/templates/shared_templates/_helpers.tpl
@@ -177,6 +177,7 @@ storageClassName: {{ .Values.resources.requests.storage.classes.binlogFiles | qu
 - name: wait-restore-backup
   image: {{ include "image_address" (dict "image" $.Values.images.toolbox) }}
   imagePullPolicy: {{ $.Values.imagePullPolicy }}
+{{ include "rondb.ContainerSecurityContext" $ | indent 2 }}
   command:
   - /bin/bash
   - -c
@@ -533,8 +534,41 @@ endpoint = {{ .global._hopsworks.managedObjectStorage.s3.endpoint }}
 {{- define "rondb.restoreFromBackup.backupId" -}}
 {{- if .Values.restoreFromBackup.backupId -}}
 {{- .Values.restoreFromBackup.backupId  -}}
-{{- else if and (include  "rondb.global.managedObjectStorage" (dict "global" .Values.global)) .Values.global._hopsworks.restoreFromBackup .Values.global._hopsworks.restoreFromBackup.backupId -}}
+{{- else if and (or (include "rondb.global.managedObjectStorage" (dict "global" .Values.global)) (include "rondb.global.minio" (dict "global" .Values.global))) .Values.global._hopsworks.restoreFromBackup .Values.global._hopsworks.restoreFromBackup.backupId -}}
 {{- .Values.global._hopsworks.restoreFromBackup.backupId -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "rondb.restoreFromBackup.inPlace" -}}
+{{- if not (eq .Values.restoreFromBackup.inPlace nil) -}}
+{{- .Values.restoreFromBackup.inPlace -}}
+{{- else if and (or (include "rondb.global.managedObjectStorage" (dict "global" .Values.global)) (include "rondb.global.minio" (dict "global" .Values.global))) .Values.global._hopsworks.restoreFromBackup .Values.global._hopsworks.restoreFromBackup.inPlace -}}
+{{- .Values.global._hopsworks.restoreFromBackup.inPlace -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "rondb.restoreFromBackup.forceDataClear" -}}
+{{- if not (eq .Values.restoreFromBackup.forceDataClear nil) -}}
+{{- .Values.restoreFromBackup.forceDataClear -}}
+{{- else if and (or (include "rondb.global.managedObjectStorage" (dict "global" .Values.global)) (include "rondb.global.minio" (dict "global" .Values.global))) .Values.global._hopsworks.restoreFromBackup .Values.global._hopsworks.restoreFromBackup.forceDataClear -}}
+{{- .Values.global._hopsworks.restoreFromBackup.forceDataClear -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "rondb.restoreFromBackup.isInPlace" -}}
+{{- if eq (include "rondb.restoreFromBackup.inPlace" .) "true" -}}
+  {{- if not (include "rondb.isUpgrade" .) -}}
+    {{- fail "\n\nERROR: restoreFromBackup.inPlace=true is only supported during 'helm upgrade'.\nAn in-place restore replaces data in an existing cluster and cannot be used during a fresh install.\nTo create a new cluster from a backup, set restoreFromBackup.inPlace=false.\n" -}}
+  {{- end -}}
+  {{- if not (include "rondb.restoreFromBackup.backupId" .) -}}
+    {{- fail "\n\nERROR: restoreFromBackup.inPlace=true requires a backup ID.\nPlease set: --set-string restoreFromBackup.backupId=<backup-id> or global._hopsworks.restoreFromBackup.backupId=<backup-id> \n" -}}
+  {{- end -}}
+  {{- if ne (include "rondb.restoreFromBackup.forceDataClear" .) "true" -}}
+    {{- fail "\n\nERROR: restoreFromBackup.inPlace=true requires explicit acknowledgment that existing data will be destroyed.\nPlease set: --set restoreFromBackup.forceDataClear=true\n\nWARNING: This will permanently delete all existing data in the cluster!\n" -}}
+  {{- end -}}
+true
+{{- else if and (include "rondb.isUpgrade" .) (include "rondb.restoreFromBackup.backupId" .) -}}
+  {{- fail "\n\nERROR: restoreFromBackup.backupId is set during an upgrade but restoreFromBackup.inPlace is not enabled.\n\nIf you intend to restore a backup into this cluster, set:\n  --set restoreFromBackup.inPlace=true --set restoreFromBackup.forceDataClear=true\nOr globally:\n  --set global._hopsworks.restoreFromBackup.inPlace=true --set global._hopsworks.restoreFromBackup.forceDataClear=true\n\nIf you are performing a normal upgrade and do not intend to restore, clear the backup ID:\n  --set-string restoreFromBackup.backupId=\nOr globally:\n  --set-string global._hopsworks.restoreFromBackup.backupId=\n" -}}
 {{- end -}}
 {{- end -}}
 

--- a/templates/shared_templates/_vars.tpl
+++ b/templates/shared_templates/_vars.tpl
@@ -41,7 +41,11 @@ backupRemote
 ---
 
 {{- define "rondb.restoreNativeBackupJobname" -}}
+{{- if include "rondb.restoreFromBackup.backupId" . -}}
+restore-native-backup-{{ include "rondb.restoreFromBackup.backupId" . }}
+{{- else -}}
 restore-native-backup
+{{- end -}}
 {{- end -}}
 
 ---

--- a/test_scripts/lifecycle-test.sh
+++ b/test_scripts/lifecycle-test.sh
@@ -6,17 +6,17 @@
 
 cat <<'EOF' >/dev/null
 This runs a test suite with the following steps:
-1. [Test: generate data] Setup cluster A, generate data
-2. [Test: replicate from scratch] Setup cluster B, replicate A->B, verify data
-3. Shut down cluster A
-4. [Test: create backup] Create backup B from cluster B
-5. [Test: restore backup] Setup cluster C, restore backup B, verify data
-6. [Test: replicate from primary's backup] Replicate B->C
-7. Shut down cluster B
-8. Setup cluster D, restore B
-9. [Test: replicate from 3rd party backup] Replicate C->D, verify data
+1.  [Test: generate data] Setup cluster A, generate data
+2.  [Test: replicate from scratch] Setup cluster B, replicate A->B, verify data
+3.  Shut down cluster A
+4.  [Test: create backup] Create backup B from cluster B
+5+6. [Test: restore backup + replicate from primary's backup] Setup cluster C, restore backup B, replicate B->C, verify data
+7.  Shut down cluster B
+8.  [Test: replicate from 3rd party backup] Setup cluster D, restore B, replicate C->D, verify data
+9.  [Test: in-place restore safeguard] Verify in-place restore rejected with existing restore jobs
+10. [Test: in-place restore] In-place restore backup B on cluster D, verify data restored, verify post-backup data gone
 
-Essentially: A->B->C->D
+Essentially: A->B->C->D, then in-place restore on D
 EOF
 
 set -e
@@ -86,6 +86,7 @@ stopReplicaAppliers() {
     helm upgrade -i $namespace \
         --namespace=$namespace \
         --reuse-values \
+        --set-string "restoreFromBackup.backupId=" \
         --set "globalReplication.secondary.enabled=false" \
         .
 }
@@ -183,18 +184,23 @@ echo "BACKUP_B_ID is ${BACKUP_B_ID}"
 
 ##########################
 # [Test: restore backup] #
-##########################
+###########################################
+# [Test: replicate from primary's backup] #
+###########################################
 
-# First just restore backup and validate data.
-# Don't start replica appliers just yet.
-# Since we will also be replicating *from* this cluster,
-# we already activate the binlog servers. Better now than
-# that they miss the first heartbeats from the primary.
+# Restore backup and set up replication from primary in a single install.
+# This avoids a separate helm upgrade to clear backupId, which would change
+# binlog server pod specs (removing restore init containers + changing SA),
+# triggering a rolling restart that writes LOST_EVENTS to the binlog.
+# The wait-restore-backup init containers ensure restore completes before
+# binlog servers and replica appliers start.
 
 kubectl create secret generic $BUCKET_SECRET_NAME \
     --namespace=$CLUSTER_C_NAME \
     --from-literal "key_id=${MINIO_ACCESS_KEY}" \
     --from-literal "access_key=${MINIO_SECRET_KEY}"
+
+BINLOG_HOSTS_B=$(getBinlogHostsString $CLUSTER_B_NAME)
 
 helm upgrade -i $CLUSTER_C_NAME \
     --namespace=$CLUSTER_C_NAME . \
@@ -212,26 +218,16 @@ helm upgrade -i $CLUSTER_C_NAME \
     --set "globalReplication.primary.maxNumBinlogServers=$MAX_NUM_BINLOG_SERVERS" \
     --set "meta.binlogServers.statefulSet.name=$BINLOG_SERVER_STATEFUL_SET" \
     --set "meta.binlogServers.headlessClusterIp.name=$BINLOG_SERVER_HEADLESS" \
-
-helm test -n $CLUSTER_C_NAME $CLUSTER_C_NAME --logs --filter name=verify-data
-
-###########################################
-# [Test: replicate from primary's backup] #
-###########################################
-
-# Now also start replicating
-
-BINLOG_HOSTS_B=$(getBinlogHostsString $CLUSTER_B_NAME)
-
-helm upgrade -i $CLUSTER_C_NAME \
-    --namespace=$CLUSTER_C_NAME . \
-    --reuse-values \
     --set "globalReplication.secondary.enabled=true" \
     --set "globalReplication.secondary.replicateFrom.clusterNumber=$CLUSTER_NUMBER_B" \
     --set "globalReplication.secondary.replicateFrom.binlogServerHosts={$BINLOG_HOSTS_B}"
 
 testStability $CLUSTER_C_NAME
-stopReplicaAppliers $CLUSTER_C_NAME
+helm test -n $CLUSTER_C_NAME $CLUSTER_C_NAME --logs --filter name=verify-data
+
+# Scale down replica appliers directly to avoid helm upgrade, which would
+# trigger the backupId validation check (backupId is still set).
+kubectl scale statefulset mysqld-replica-appliers -n $CLUSTER_C_NAME --replicas=0
 deleteCluster $CLUSTER_B_NAME
 
 ###########################################
@@ -265,6 +261,70 @@ helm upgrade -i $CLUSTER_D_NAME \
 helm test -n $CLUSTER_D_NAME $CLUSTER_D_NAME --logs --filter name=verify-data
 
 testStability $CLUSTER_D_NAME
+
+######################################
+# [Test: in-place restore safeguard] #
+#   [Test: in-place restore backup]  #
+######################################
+
+# Run this at the end to avoid interfering with the other tests.
+# We use Cluster D which already has the backup restored.
+
+# Get root password from secret
+MYSQL_ROOT_PASSWORD=$(kubectl get secret $MYSQL_SECRET_NAME -n $CLUSTER_D_NAME -o jsonpath='{.data.root}' | base64 -d)
+
+# Add post-backup data (should NOT exist after restore)
+MYSQLD_POD=$(kubectl get pods -n $CLUSTER_D_NAME -l rondbService=mysqld -o jsonpath='{.items[0].metadata.name}')
+kubectl exec -n $CLUSTER_D_NAME $MYSQLD_POD -- mysql -uroot -p"$MYSQL_ROOT_PASSWORD" -e "INSERT INTO helmtest.t7 VALUES(9999, 9999, NOW(), 'post-backup-data');"
+
+# Verify post-backup data exists
+kubectl exec -n $CLUSTER_D_NAME $MYSQLD_POD -- mysql -uroot -p"$MYSQL_ROOT_PASSWORD" -e "SELECT * FROM helmtest.t7 WHERE id=9999;" | grep -q "post-backup-data"
+echo "Post-backup data verified present before in-place restore"
+
+# Scale down replica appliers directly to avoid helm upgrade, which would
+# delete the restore jobs (they're conditional on backupId being set).
+# The restore jobs must remain for the safeguard test below.
+kubectl scale statefulset mysqld-replica-appliers -n $CLUSTER_D_NAME --replicas=0
+
+# Test safeguard: Try in-place restore WITHOUT deleting old jobs first
+# The pre-upgrade hook should detect the completed restore job and fail
+echo "Testing safeguard: attempting in-place restore with existing restore job..."
+if helm upgrade -i $CLUSTER_D_NAME \
+    --namespace=$CLUSTER_D_NAME . \
+    --reuse-values \
+    --values $restore_values_file \
+    --set-string "restoreFromBackup.backupId=$BACKUP_B_ID" \
+    --set "restoreFromBackup.inPlace=true" \
+    --set "restoreFromBackup.forceDataClear=true" 2>&1; then
+    echo "ERROR: Safeguard failed! Helm upgrade should have failed but succeeded."
+    exit 1
+fi
+echo "Safeguard test PASSED: in-place restore was correctly rejected"
+
+# Now delete the restore jobs to allow a fresh in-place restore
+echo "Deleting restore jobs to allow in-place restore..."
+kubectl delete job "setup-mysqld-dont-remove-$BACKUP_B_ID" -n $CLUSTER_D_NAME --ignore-not-found=true
+kubectl delete job "restore-native-backup-$BACKUP_B_ID" -n $CLUSTER_D_NAME --ignore-not-found=true
+
+# Run in-place restore
+helm upgrade -i $CLUSTER_D_NAME \
+    --namespace=$CLUSTER_D_NAME . \
+    --reuse-values \
+    --values $restore_values_file \
+    --set-string "restoreFromBackup.backupId=$BACKUP_B_ID" \
+    --set "restoreFromBackup.inPlace=true" \
+    --set "restoreFromBackup.forceDataClear=true"
+
+testStability $CLUSTER_D_NAME
+helm test -n $CLUSTER_D_NAME $CLUSTER_D_NAME --logs --filter name=verify-data
+
+# Verify post-backup data is GONE
+MYSQLD_POD=$(kubectl get pods -n $CLUSTER_D_NAME -l rondbService=mysqld -o jsonpath='{.items[0].metadata.name}')
+if kubectl exec -n $CLUSTER_D_NAME $MYSQLD_POD -- mysql -uroot -p"$MYSQL_ROOT_PASSWORD" -e "SELECT * FROM helmtest.t7 WHERE id=9999;" 2>/dev/null | grep -q "post-backup-data"; then
+    echo "ERROR: Post-backup data still exists after in-place restore!"
+    exit 1
+fi
+echo "In-place restore test PASSED"
 
 deleteCluster $CLUSTER_C_NAME
 deleteCluster $CLUSTER_D_NAME

--- a/values.schema.json
+++ b/values.schema.json
@@ -1615,6 +1615,16 @@
                     "items": {
                         "type": "string"
                     }
+                },
+                "inPlace": {
+                    "description": "Enable in-place restore on existing cluster. Requires forceDataClear=true.",
+                    "type": ["boolean", "null"],
+                    "default": null
+                },
+                "forceDataClear": {
+                    "description": "Confirm that existing data will be destroyed during in-place restore.",
+                    "type": ["boolean", "null"],
+                    "default": null
                 }
             },
             "required": []

--- a/values.yaml
+++ b/values.yaml
@@ -307,6 +307,8 @@ restoreFromBackup:
   backupId: null
   excludeDatabases: []
   excludeTables: []
+  forceDataClear: null
+  inPlace: null
   objectStorageProvider: s3
   pathPrefix: rondb_backup
   s3:


### PR DESCRIPTION
Fixes https://hopsworks.atlassian.net/browse/HWORKS-2002

Enable restoring a backup on an existing RonDB cluster via helm upgrade. Previously, restore only worked on fresh installs.

New values under restoreFromBackup:
- inPlace: Enable in-place restore mode
- forceDataClear: Safety confirmation that existing data will be destroyed

When both flags are set during helm upgrade:
1. Pre-upgrade hook shuts down all services (scales StatefulSets to 0)
2. Main upgrade recreates resources with --initial flag to wipe and restore

Key implementation details:
- Pre-upgrade hook deletes old markers, scales down services in correct order
- Job names now include backup ID for uniqueness across restores
- Marker file mechanism ensures safe --initial handling with crash recovery
- Data nodes use FORCE_INITIAL_START env var to trigger --initial on restart