### PR TITLE
[CLOUD-788] Add PodDisruptionBudget support for ndbmtd, rdrs, and mysqld

### DIFF
--- a/templates/pdb.yaml
+++ b/templates/pdb.yaml
@@ -1,0 +1,69 @@
+# Copyright (c) 2024-2026 Hopsworks AB. All rights reserved.
+
+# PodDisruptionBudgets to ensure availability during node drains (e.g. EKS node group upgrades).
+# Each PDB ensures at least N pods remain available so Kubernetes won't drain a node
+# until replicas on other nodes have been updated and are running.
+# PDBs are skipped when there is only a single replica, as a PDB would block all
+# node drains in that case.
+
+{{- if not (include "rondb.isExternallyManaged" .) -}}
+{{- if $.Values.podDisruptionBudget.ndbmtd.enabled }}
+{{- if gt ($.Values.clusterSize.activeDataReplicas | int) 1 }}
+{{- if ge ($.Values.podDisruptionBudget.ndbmtd.minAvailable | int) ($.Values.clusterSize.activeDataReplicas | int) }}
+{{- fail (printf "podDisruptionBudget.ndbmtd.minAvailable (%d) must be less than clusterSize.activeDataReplicas (%d), otherwise all drains will be blocked" ($.Values.podDisruptionBudget.ndbmtd.minAvailable | int) ($.Values.clusterSize.activeDataReplicas | int)) }}
+{{- end }}
+{{ range $nodeGroup := until ($.Values.clusterSize.numNodeGroups | int) }}
+---
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: node-group-{{ $nodeGroup }}-pdb
+  namespace: {{ $.Release.Namespace }}
+spec:
+  minAvailable: {{ $.Values.podDisruptionBudget.ndbmtd.minAvailable }}
+  selector:
+    matchLabels:
+      rondbService: {{ include "rondb.labels.rondbService.ndbmtd" $ }}
+      nodeGroup: {{ $nodeGroup | quote }}
+{{ end }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{- if $.Values.podDisruptionBudget.rdrs.enabled }}
+{{- if gt ($.Values.clusterSize.minNumRdrs | int) 1 }}
+{{- if ge ($.Values.podDisruptionBudget.rdrs.minAvailable | int) ($.Values.clusterSize.minNumRdrs | int) }}
+{{- fail (printf "podDisruptionBudget.rdrs.minAvailable (%d) must be less than clusterSize.minNumRdrs (%d), otherwise all drains will be blocked" ($.Values.podDisruptionBudget.rdrs.minAvailable | int) ($.Values.clusterSize.minNumRdrs | int)) }}
+{{- end }}
+---
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: rdrs-pdb
+  namespace: {{ .Release.Namespace }}
+spec:
+  minAvailable: {{ .Values.podDisruptionBudget.rdrs.minAvailable }}
+  selector:
+    matchLabels:
+      rondbService: {{ include "rondb.labels.rondbService.rdrs" $ }}
+{{- end }}
+{{- end }}
+
+{{- if $.Values.podDisruptionBudget.mysqld.enabled }}
+{{- if gt ($.Values.clusterSize.minNumMySQLServers | int) 1 }}
+{{- if ge ($.Values.podDisruptionBudget.mysqld.minAvailable | int) ($.Values.clusterSize.minNumMySQLServers | int) }}
+{{- fail (printf "podDisruptionBudget.mysqld.minAvailable (%d) must be less than clusterSize.minNumMySQLServers (%d), otherwise all drains will be blocked" ($.Values.podDisruptionBudget.mysqld.minAvailable | int) ($.Values.clusterSize.minNumMySQLServers | int)) }}
+{{- end }}
+---
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: mysqld-pdb
+  namespace: {{ .Release.Namespace }}
+spec:
+  minAvailable: {{ .Values.podDisruptionBudget.mysqld.minAvailable }}
+  selector:
+    matchLabels:
+      rondbService: {{ include "rondb.labels.rondbService.mysqld" $ }}
+{{- end }}
+{{- end }}

--- a/values.schema.json
+++ b/values.schema.json
@@ -1826,6 +1826,54 @@
                 }
             }
         },
+        "podDisruptionBudget": {
+            "type": "object",
+            "description": "PodDisruptionBudget configuration per service. Ensures pod availability during voluntary disruptions like node drains and EKS node group upgrades. For single-replica deployments (effective replicas == 1), the PDB is not created even if minAvailable is 1, to avoid blocking node drains. For multi-replica deployments (effective replicas > 1), template rendering will fail if minAvailable is greater than or equal to the effective replica count, because such a PDB would prevent voluntary disruptions. The effective replica count used in these checks is the configured minimum replica count for each service (for example, clusterSize.minNumMySQLServers / clusterSize.minNumRdrs), not any dynamically autoscaled replica count at runtime.",
+            "properties": {
+                "mysqld": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "default": true
+                        },
+                        "minAvailable": {
+                            "type": "integer",
+                            "default": 1,
+                            "minimum": 1
+                        }
+                    }
+                },
+                "ndbmtd": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "default": true
+                        },
+                        "minAvailable": {
+                            "type": "integer",
+                            "default": 1,
+                            "minimum": 1
+                        }
+                    }
+                },
+                "rdrs": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "default": true
+                        },
+                        "minAvailable": {
+                            "type": "integer",
+                            "default": 1,
+                            "minimum": 1
+                        }
+                    }
+                }
+            }
+        },
         "tolerations": {
             "type": "object",
             "description": "These tolerations allow Kubernetes to schedule pods on nodes with matching taints, ensuring proper placement based on cluster policies.",

--- a/values.yaml
+++ b/values.yaml
@@ -241,6 +241,16 @@ nodeSelector:
   mysqld: {}
   ndbmtd: {}
   rdrs: {}
+podDisruptionBudget:
+  mysqld:
+    enabled: true
+    minAvailable: 1
+  ndbmtd:
+    enabled: true
+    minAvailable: 1
+  rdrs:
+    enabled: true
+    minAvailable: 1
 priorityClass: rondb-high-priority
 rdrs:
   externalMetadataCluster:


### PR DESCRIPTION
Ensures pod availability during voluntary disruptions like EKS node group upgrades by preventing Kubernetes from draining a node until replicas on other nodes are healthy. PDBs are enabled by default but silently skipped when only a single replica is configured. A misconfiguration error is raised if minAvailable >= replicas with more than one replica.
Fixes https://hopsworks.atlassian.net/browse/CLOUD-788