### PR TITLE
RONDB-1054: Roll MGMd before other StatefulSets on upgrade

### DIFF
--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -378,38 +378,41 @@ jobs:
           done
           kubectl delete priorityclass rondb-high-priority 2>/dev/null || true
 
-      # Install the OLD chart. Three sizing/config overrides are needed
-      # to make the install fit and start cleanly on the minikube runner:
-      #   1. `--values ./old-chart/values/minikube/mini.yaml` overlays
-      #      the same minikube-friendly resource requests
-      #      benchmark-and-stability uses; the chart's default
-      #      values.yaml is sized for production hardware.
-      #   2. `--set clusterSize.activeDataReplicas=2` overrides
-      #      mini.yaml's default of 1 — A1/A2 only have meaning with
-      #      at least 2 data-node replicas.
-      #   3. `--set backups.enabled=false` disables the rclone-listener
-      #      sidecar on every ndbmtd pod. The OLD chart 0.7.29 ships
-      #      `backups.enabled: true` plus a hardcoded `aws-credentials`
-      #      Secret reference (the chart-default S3 config points at
-      #      a real Hopsworks bucket); without that Secret the sidecar
-      #      crash-loops, pods stay 1/2 Ready forever, and helm --wait
-      #      hits the timeout. The NEW chart (25.10.6) defaults this
-      #      to `null` (falsy) so the override is carried through
-      #      `--reuse-values` as a no-op.
+      # Install the OLD chart. We overlay `values/minikube/small.yaml`
+      # rather than mini.yaml because small.yaml is the OLD chart's
+      # purpose-built config for the `numNodeGroups: 1,
+      # activeDataReplicas: 2` topology this test needs (mini.yaml
+      # targets `activeDataReplicas: 1` and ships smaller memory
+      # tunings — `TransactionMemory: 150M`, `SharedGlobalMemory:
+      # 150M` — that don't allow the 2-replica cluster to form on
+      # the minikube runner). small.yaml provides the right cluster
+      # shape *and* `TransactionMemory: 300M` / `SharedGlobalMemory:
+      # 300M` for replication.
+      #
+      # `--set` overrides on top of small.yaml:
+      #   - `staticCpuManagerPolicy=true` matches benchmark-and-stability.
+      #   - `clusterSize.minNumMySQLServers / maxNumMySQLServers = 1`
+      #     overrides small.yaml's 2 — one mysqld is enough to
+      #     exercise the upgrade path and saves a pod's worth of
+      #     resources on the runner.
+      #   - `rondbConfig.TotalMemoryConfig=2048M` per the test spec.
+      #   - `backups.enabled=false` removes the rclone-listener
+      #     sidecar; the OLD chart 0.7.29 defaults `backups.enabled:
+      #     true` plus a hardcoded `aws-credentials` Secret reference
+      #     that doesn't exist in CI, which would otherwise
+      #     crash-loop the sidecar and block helm --wait. The NEW
+      #     chart (25.10.6) defaults this to `null` so the override
+      #     carries through `--reuse-values` as a no-op.
       - name: Install old chart (0.7.29 / 24.10.19)
         run: |
           helm install $RONDB_CLUSTER_NAME ./old-chart \
             --namespace=$K8S_NAMESPACE \
             --create-namespace \
             --wait --timeout=15m \
-            --values ./old-chart/values/minikube/mini.yaml \
+            --values ./old-chart/values/minikube/small.yaml \
             --set staticCpuManagerPolicy=true \
-            --set clusterSize.numNodeGroups=1 \
-            --set clusterSize.activeDataReplicas=2 \
             --set clusterSize.minNumMySQLServers=1 \
             --set clusterSize.maxNumMySQLServers=1 \
-            --set clusterSize.minNumRdrs=1 \
-            --set clusterSize.maxNumRdrs=1 \
             --set rondbConfig.TotalMemoryConfig=2048M \
             --set backups.enabled=false
 

--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -112,6 +112,7 @@ jobs:
           helm install $RONDB_CLUSTER_NAME \
             --namespace=$K8S_NAMESPACE \
             --create-namespace \
+            --timeout=15m \
             --values ./values/minikube/mini.yaml \
             --set benchmarking.enabled=true \
             --set staticCpuManagerPolicy=true \
@@ -159,6 +160,7 @@ jobs:
         run: |
           helm upgrade -i $RONDB_CLUSTER_NAME \
             --namespace=$K8S_NAMESPACE \
+            --timeout=15m \
             --reuse-values \
             --set clusterSize.minNumMySQLServers=2 \
             --set clusterSize.activeDataReplicas=2 \
@@ -178,6 +180,7 @@ jobs:
         run: |
           helm upgrade -i $RONDB_CLUSTER_NAME \
             --namespace=$K8S_NAMESPACE \
+            --timeout=15m \
             --reuse-values \
             --set rondbConfig.EmptyApiSlots=5 \
             .

--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -378,16 +378,24 @@ jobs:
           done
           kubectl delete priorityclass rondb-high-priority 2>/dev/null || true
 
-      # Install the OLD chart. We overlay the OLD chart's
-      # values/minikube/mini.yaml for resource-request sizing (the same
-      # overlay that benchmark-and-stability uses) — the chart's default
-      # values.yaml has per-pod memory limits and PV requests
-      # (ndbmtdsMiB=5000, ndbmtdGiB=30, redoLogGiB=4, …) that are sized
-      # for production and don't fit the ARM64 minikube runner. The
-      # `--set clusterSize.*` overrides are applied after the values
-      # overlay; in particular `activeDataReplicas=2` is needed because
-      # mini.yaml defaults to 1, and the arbitration scenario A1/A2
-      # asserts only have meaning with at least 2 data-node replicas.
+      # Install the OLD chart. Three sizing/config overrides are needed
+      # to make the install fit and start cleanly on the minikube runner:
+      #   1. `--values ./old-chart/values/minikube/mini.yaml` overlays
+      #      the same minikube-friendly resource requests
+      #      benchmark-and-stability uses; the chart's default
+      #      values.yaml is sized for production hardware.
+      #   2. `--set clusterSize.activeDataReplicas=2` overrides
+      #      mini.yaml's default of 1 — A1/A2 only have meaning with
+      #      at least 2 data-node replicas.
+      #   3. `--set backups.enabled=false` disables the rclone-listener
+      #      sidecar on every ndbmtd pod. The OLD chart 0.7.29 ships
+      #      `backups.enabled: true` plus a hardcoded `aws-credentials`
+      #      Secret reference (the chart-default S3 config points at
+      #      a real Hopsworks bucket); without that Secret the sidecar
+      #      crash-loops, pods stay 1/2 Ready forever, and helm --wait
+      #      hits the timeout. The NEW chart (25.10.6) defaults this
+      #      to `null` (falsy) so the override is carried through
+      #      `--reuse-values` as a no-op.
       - name: Install old chart (0.7.29 / 24.10.19)
         run: |
           helm install $RONDB_CLUSTER_NAME ./old-chart \
@@ -402,7 +410,8 @@ jobs:
             --set clusterSize.maxNumMySQLServers=1 \
             --set clusterSize.minNumRdrs=1 \
             --set clusterSize.maxNumRdrs=1 \
-            --set rondbConfig.TotalMemoryConfig=2048M
+            --set rondbConfig.TotalMemoryConfig=2048M \
+            --set backups.enabled=false
 
       # Snapshot the current cluster.log line count so the post-upgrade
       # assertion (A2) only inspects lines emitted during the upgrade

--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -378,45 +378,24 @@ jobs:
           done
           kubectl delete priorityclass rondb-high-priority 2>/dev/null || true
 
-      # Install the OLD chart. We overlay `values/minikube/small.yaml`
-      # rather than mini.yaml because small.yaml is the OLD chart's
-      # purpose-built config for the `numNodeGroups: 1,
-      # activeDataReplicas: 2` topology this test needs (mini.yaml
-      # targets `activeDataReplicas: 1` and ships smaller memory
-      # tunings — `TransactionMemory: 150M`, `SharedGlobalMemory:
-      # 150M` — that don't allow the 2-replica cluster to form on
-      # the minikube runner). small.yaml provides the right cluster
-      # shape *and* `TransactionMemory: 300M` / `SharedGlobalMemory:
-      # 300M` for replication.
+      # Install the OLD chart with small.yaml — needed for the
+      # `numNodeGroups: 1, activeDataReplicas: 2` topology this test
+      # exercises (mini.yaml ships `activeDataReplicas: 1` and smaller
+      # memory tunings).
       #
-      # `--set` overrides on top of small.yaml:
-      #   - `staticCpuManagerPolicy=true` matches benchmark-and-stability.
-      #   - `clusterSize.minNumMySQLServers / maxNumMySQLServers = 1`
-      #     overrides small.yaml's 2 — one mysqld is enough to
-      #     exercise the upgrade path and saves a pod's worth of
-      #     resources on the runner.
-      #   - `rondbConfig.TotalMemoryConfig=4096M` matches the
-      #     known-good value benchmark-and-stability uses. The 1x2
-      #     topology with small.yaml's TransactionMemory=300M /
-      #     SharedGlobalMemory=300M reserves ~3 GB before DataMemory;
-      #     RonDB requires >=3589 MB total for AutomaticMemoryConfig
-      #     to succeed. 2048M would fail in startphase 0 with
-      #     `error 2350: Invalid configuration received from
-      #     Management Server`.
-      #   - `resources.limits.memory.ndbmtdsMiB=5120` raises the
-      #     ndbmtd container's cgroup memory limit from small.yaml's
-      #     default 3300 MiB. With TotalMemoryConfig=4096M, RonDB
-      #     auto-config plans ~3 GB of touched pages plus headroom,
-      #     which exceeds 3300 MiB and gets the pod OOM-killed (SIGKILL)
-      #     at startphase 0. 5120 mirrors what mini.yaml uses for the
-      #     same TotalMemoryConfig in benchmark-and-stability.
-      #   - `backups.enabled=false` removes the rclone-listener
-      #     sidecar; the OLD chart 0.7.29 defaults `backups.enabled:
-      #     true` plus a hardcoded `aws-credentials` Secret reference
-      #     that doesn't exist in CI, which would otherwise
-      #     crash-loop the sidecar and block helm --wait. The NEW
-      #     chart (25.10.6) defaults this to `null` so the override
-      #     carries through `--reuse-values` as a no-op.
+      # --set overrides:
+      #   - clusterSize.{min,max}NumMySQLServers=1: one mysqld is
+      #     enough to exercise the upgrade and saves runner resources.
+      #   - TotalMemoryConfig=4096M: AutomaticMemoryConfig requires
+      #     >=3589 MB on this 1x2 topology with small.yaml's memory
+      #     reservations; 2048M fails with NDB error 2350.
+      #   - resources.limits.memory.ndbmtdsMiB=5120: small.yaml's 3300
+      #     MiB cap is below what TotalMemoryConfig=4096M needs at
+      #     startphase 0; without this the pod is cgroup-OOM-killed.
+      #   - backups.enabled=false: 0.7.29 defaults `backups.enabled:
+      #     true` with a hardcoded aws-credentials Secret that doesn't
+      #     exist in CI; the new chart defaults to null so this carries
+      #     through as a no-op.
       - name: Install old chart (0.7.29 / 24.10.19)
         run: |
           helm install $RONDB_CLUSTER_NAME ./old-chart \
@@ -431,28 +410,12 @@ jobs:
             --set resources.limits.memory.ndbmtdsMiB=5120 \
             --set backups.enabled=false
 
-      # Inline diagnostics on install failure. The install runs `helm
-      # --wait` (silent until success or timeout), so without these
-      # the only signal a future failure leaves in the runner log is
-      # `context deadline exceeded` — debugging requires downloading
-      # the cross_version_logs artifact. Print pod state, events, and
-      # the last lines of every container's current+previous log so
-      # the failure root cause is visible inline.
-      #
-      # Each section answers a specific failure-mode question that
-      # would otherwise force you into the artifact:
-      #   pods / events / container logs — "what's RonDB itself saying?"
-      #   pod descriptions               — "was it OOMKilled? exit code?
-      #                                     signal? lastState reason?"
-      #   container resource limits      — "what cgroup ceiling did the
-      #                                     chart actually render? did
-      #                                     our --set overrides land?"
-      #   node state + top               — "is this node-OOM or
-      #                                     container-cgroup OOM? are we
-      #                                     near node MemoryPressure?"
-      #   helm get values                — "did the --set overrides
-      #                                     resolve to the values we
-      #                                     intended (typo check)?"
+      # Inline diagnostics on install failure. `helm --wait` is silent
+      # until success or timeout, so without these a failure surfaces
+      # in the runner log only as `context deadline exceeded`. Each
+      # section below targets a specific failure-mode question
+      # (OOMKilled vs node-OOM, --set typos, schema rejection, unbound
+      # PVCs, cluster-wide RonDB events).
       - name: Diagnostics on install failure
         if: failure()
         run: |
@@ -463,11 +426,9 @@ jobs:
               | tail -n 30 || true
           echo "=== ndbmtd / mgmd / rdrs / mysqld container logs (last 50 lines each) ==="
           for pod in $(kubectl -n $K8S_NAMESPACE get pods -o jsonpath='{.items[*].metadata.name}'); do
-            # Init containers first — a pod stuck in Init:N/M (e.g. the
-            # wait-datanodes-dependency / mgmd-dependency-check chain on
-            # mysqlds-0) has its real failure narrative in init logs.
-            # `.spec.containers[*]` does not include init containers, so
-            # iterating it alone silently skips them.
+            # Init containers first — a pod stuck in Init:N/M has its
+            # failure narrative here, and `.spec.containers[*]` alone
+            # silently skips them.
             for c in $(kubectl -n $K8S_NAMESPACE get pod "$pod" -o jsonpath='{.spec.initContainers[*].name}'); do
               echo "--- $pod / $c (init, current) ---"
               kubectl -n $K8S_NAMESPACE logs "$pod" -c "$c" --tail=50 2>&1 || true
@@ -481,21 +442,14 @@ jobs:
               kubectl -n $K8S_NAMESPACE logs "$pod" -c "$c" --previous --tail=50 2>&1 || true
             done
           done
+          # `kubectl describe pod` surfaces lastState.terminated
+          # (Reason=OOMKilled, ExitCode=137, Signal=...) plus per-container
+          # Limits — the direct answer to "why did this container die".
           echo "=== pod descriptions (lastState.terminated: reason, exitCode, signal) ==="
-          # `kubectl describe pod` prints `Last State: Terminated` with
-          # Reason / Exit Code / Signal / Started / Finished — the direct
-          # answer to "why did this container die" with no inference
-          # required (e.g. Reason=OOMKilled, ExitCode=137 makes
-          # cgroup-OOM unambiguous). Also includes the per-container
-          # `Limits:` block as the kubelet sees it.
           kubectl -n $K8S_NAMESPACE describe pods || true
+          # Verifies `--set resources.limits.memory.*` actually
+          # propagated. A typo in the dotted path silently no-ops.
           echo "=== container resource limits as rendered by the chart ==="
-          # Sanity-check that our `--set resources.limits.memory.*`
-          # overrides actually propagated through `helm install` to the
-          # live StatefulSet spec. A typo in the dotted path would
-          # silently no-op and let the cluster boot with whatever the
-          # overlay's default was — exactly the failure shape that
-          # produced the OOM-kill we just debugged.
           for sts in $(kubectl -n $K8S_NAMESPACE get statefulset \
                          -o jsonpath='{.items[*].metadata.name}'); do
             echo "--- statefulset/$sts ---"
@@ -504,48 +458,34 @@ jobs:
               || true
             echo
           done
+          # Distinguishes container-cgroup OOM from node-level memory
+          # pressure (MemoryPressure=True + Allocated resources table).
           echo "=== node state (MemoryPressure, Allocatable vs Allocated) ==="
-          # Distinguishes container-cgroup OOM (one container killed,
-          # node healthy) from node-level memory exhaustion (node tainted
-          # MemoryPressure=True, multiple pods evicted). The Conditions
-          # block and the Allocated resources table at the bottom of
-          # `describe node` answer this in one screen.
           kubectl describe nodes || true
           echo "=== resource utilisation (only printed if metrics-server is up) ==="
           kubectl top nodes 2>&1 || true
           kubectl -n $K8S_NAMESPACE top pods 2>&1 || true
+          # Resolved values (defaults + overlay + every --set). Catches
+          # missing/typo'd overrides at a glance.
           echo "=== helm release: resolved values (post --set) ==="
-          # `helm get values --all` shows the merged result of the
-          # default values.yaml + --values overlay + every --set, so a
-          # missing/typo'd override is visible at a glance.
           helm get values $RONDB_CLUSTER_NAME -n $K8S_NAMESPACE --all || true
+          # Release-level state for failures where pod-side diagnostics
+          # are partial or empty (schema rejection, hook non-zero exit).
           echo "=== helm release: history + status ==="
-          # Catches release-level failures where pod-side diagnostics
-          # are partial or empty: schema rejection that throws after
-          # some manifests have applied, post-render failures, hook
-          # job non-zero exits etc. `helm status` prints the LAST
-          # DEPLOYED stamp, deployed/failed marker, and any
-          # NOTES.txt-rendered tail; `helm history` shows whether the
-          # current revision was a successful deploy or a `failed` one.
           helm history $RONDB_CLUSTER_NAME -n $K8S_NAMESPACE || true
           helm status  $RONDB_CLUSTER_NAME -n $K8S_NAMESPACE || true
+          # Unbound PVCs surface only as Pending; not in pod logs.
           echo "=== persistent volume claims (binding state) ==="
-          # Unbound PVCs are a real minikube failure mode (storageClass
-          # naming drift, hostpath provisioner unhealthy, capacity
-          # exhausted). They surface here as `Pending` rather than
-          # anywhere in the per-pod logs.
           kubectl -n $K8S_NAMESPACE get pvc -o wide || true
           for pvc in $(kubectl -n $K8S_NAMESPACE get pvc \
                          -o jsonpath='{range .items[?(@.status.phase!="Bound")]}{.metadata.name} {end}'); do
             echo "--- pvc/$pvc (not Bound) ---"
             kubectl -n $K8S_NAMESPACE describe pvc "$pvc" || true
           done
+          # Cluster-wide RonDB events (data-node connect/disconnect,
+          # arbitration decisions, GCP rounds) not visible in
+          # per-container logs.
           echo "=== cluster.log tail (mgmd's authoritative cluster narrative) ==="
-          # mgmd's cluster.log records cluster-wide events that no
-          # per-container kubectl-logs view captures: data-node connect
-          # / disconnect, arbitrator decisions (Error 2305 candidates),
-          # GCP rounds, schema-op outcomes. If MGMd itself is down the
-          # exec fails and the `|| true` keeps the step going.
           kubectl -n $K8S_NAMESPACE exec mgmds-0 -c mgmd -- \
               tail -n 200 /srv/hops/mysql-cluster/log/cluster.log 2>&1 || true
 
@@ -560,15 +500,11 @@ jobs:
           echo "Captured cluster.log offset: $OFFSET"
           echo "$OFFSET" > /tmp/cluster-log-offset.txt
 
-      # Re-supply the install's values on the upgrade rather than using
-      # `--reuse-values`. Per maintainer guidance, Hopsworks customers
-      # always pass their values files on every `helm upgrade` rather
-      # than relying on `--reuse-values`, so the test mirrors that
-      # flow. Practical effect: the new chart's `values.yaml` defaults
-      # are merged in (filling in any schema-required fields the OLD
-      # chart didn't ship — e.g. `meta.ddlMySQLd` added in HWORKS-2753),
-      # and the operator-supplied overlay + --set carry the
-      # cluster-shape and resource overrides forward.
+      # Re-supply install values on upgrade (no `--reuse-values`).
+      # Per maintainer, Hopsworks customers always pass values files
+      # on every upgrade. Practical effect: new-chart defaults are
+      # merged in (filling schema-required fields the OLD chart
+      # didn't ship, e.g. `meta.ddlMySQLd` from HWORKS-2753).
       - name: Upgrade to new chart (PR head)
         run: |
           helm upgrade $RONDB_CLUSTER_NAME ./new-chart \
@@ -587,10 +523,8 @@ jobs:
       - name: Assert no arbitration loss (Error 2305)
         run: |
           fail=0
-          # Refuse-to-pass if the label selector matches zero pods. Without
-          # this guard, a future chart rename of the `rondbService` label
-          # value would silently iterate zero pods and let A1 pass on a
-          # cluster that hasn't actually been checked.
+          # Refuse-to-pass on empty selector — guards against silent
+          # pass if the chart ever renames the rondbService label.
           pods=$(kubectl -n $K8S_NAMESPACE get pods -l rondbService=ndbmtd \
                    -o jsonpath='{.items[*].metadata.name}')
           if [ -z "$pods" ]; then
@@ -609,25 +543,16 @@ jobs:
           done
           exit $fail
 
-      # A2: A "system restart" line means every data node was down
-      # simultaneously. The slice starts at the snapshotted offset so we
-      # ignore the initial install's own startup messages.
+      # A2: a true system restart means every data node was down
+      # simultaneously. The slice starts at the snapshotted offset so
+      # we skip the install's own startup messages.
       #
-      # Match on the explicit `Start node: N using system restart`
-      # decision line rather than on the `Start phase 0 completed
-      # (system restart)` placeholder. Phases 0 and 1 are logged with
-      # the `(system restart)` tag on *every* ndbmtd boot — including
-      # routine node-restarts during a rolling upgrade — because the
-      # restart-type decision is made after phase 1. By phase 2 the
-      # log line transitions to `(node restart)` if MGMd reports a
-      # live peer. Grepping the placeholder produces a false positive
-      # on every successful rolling upgrade.
-      #
-      # `Start node: <id> using system restart` is logged only when
-      # MGMd has decided the booting node must do a true system
-      # restart (no live peer at decision time, i.e. the cluster lost
-      # quorum). That is exactly the failure mode this assertion
-      # exists to catch.
+      # Match `Start node: N using system restart` (MGMd's explicit
+      # decision), NOT `Start phase 0 completed (system restart)` —
+      # the latter is a placeholder logged on every ndbmtd boot
+      # (including routine node-restarts) before the restart type is
+      # decided at phase 2, so it false-positives on every successful
+      # rolling upgrade.
       - name: Assert no system restart in upgrade window
         run: |
           OFFSET=$(cat /tmp/cluster-log-offset.txt)
@@ -635,24 +560,18 @@ jobs:
               tail -n +$((OFFSET + 1)) /srv/hops/mysql-cluster/log/cluster.log)
           if echo "$slice" | grep -E 'Start node: [0-9]+ using system restart'; then
             echo "::error::cluster.log shows a true system restart (lost quorum) during the upgrade window"
-            # Dump the full upgrade-window slice so the diagnosis is visible
-            # inline rather than buried in the cross_version_logs artifact.
-            # The slice + context covers data-node connect/disconnect events,
-            # MGMd restart timing, and arbitration decisions — exactly what's
-            # needed to tell C1 (parallel rolling) from C2 (hook-induced
-            # shutdown) from C3 (protocol kick-off).
+            # Full slice for inline diagnosis (parallel rolling vs.
+            # hook-induced shutdown vs. protocol kick-off).
             echo "=== full cluster.log slice (lines after $OFFSET) ==="
             echo "$slice"
             exit 1
           fi
           echo "No true system-restart decisions in upgrade-window slice (lines after $OFFSET)."
 
-      # On any assertion failure, print pod-level evidence so the diagnosis
-      # is visible inline rather than requiring the cross_version_logs
-      # artifact download. Specifically: ndbmtd pod restart history (from
-      # `kubectl describe pod` lastState + container restart counts), recent
-      # events filtered to data-node pods, and each ndbmtd's previous-pod
-      # logs (where the last ~50 lines before the kill live).
+      # On assertion failure, print pod-level evidence inline (restart
+      # counts, lastState, ndbmtd-pod events, previous-pod logs, and
+      # each StatefulSet's rendered podManagementPolicy +
+      # updateStrategy) so diagnosis doesn't require an artifact pull.
       - name: Diagnostics on upgrade/assertion failure
         if: failure()
         run: |
@@ -667,13 +586,13 @@ jobs:
           kubectl -n $K8S_NAMESPACE get events --sort-by='.metadata.creationTimestamp' \
             --field-selector involvedObject.kind=Pod 2>&1 \
             | grep -E 'node-group|ndbmtd' || true
-          echo "=== ndbmtd previous-pod logs (last 80 lines, the dying breath of the OLD-image pod) ==="
+          echo "=== ndbmtd previous-pod logs (OLD-image pod's last 80 lines before kill) ==="
           for pod in $(kubectl -n $K8S_NAMESPACE get pods -l rondbService=ndbmtd \
                          -o jsonpath='{.items[*].metadata.name}'); do
             echo "--- $pod / ndbmtd (previous) ---"
             kubectl -n $K8S_NAMESPACE logs "$pod" -c ndbmtd --previous --tail=80 2>&1 || true
           done
-          echo "=== ndbmtd current-pod logs (last 80 lines, the NEW-image boot story) ==="
+          echo "=== ndbmtd current-pod logs (NEW-image pod's first 80 lines) ==="
           for pod in $(kubectl -n $K8S_NAMESPACE get pods -l rondbService=ndbmtd \
                          -o jsonpath='{.items[*].metadata.name}'); do
             echo "--- $pod / ndbmtd (current) ---"
@@ -688,15 +607,10 @@ jobs:
               2>&1 || true
           done
 
-      # A3: Sanity check that the upgrade actually touched MGMd's image.
-      # If the values overlay produced a no-op or the hook somehow blocked
-      # the spec change, A1/A2 might pass for the wrong reason.
-      #
-      # The hardcoded `:24.10.19` is paired with the OLD-chart pin in the
-      # `Checkout old chart` step (`ref: branch-0.7`, which ships RonDB
-      # 24.10.19). If that pin ever moves to a different OLD-chart
-      # branch, update the version string below so this assertion stays
-      # meaningful — otherwise it will silently pass on any image.
+      # A3: sanity check that the upgrade actually touched MGMd's image,
+      # so A1/A2 don't pass for the wrong reason. The `:24.10.19` is
+      # paired with the OLD-chart pin (`ref: branch-0.7`); update both
+      # together if you ever change which OLD chart this test runs against.
       - name: Assert MGMd image was upgraded
         run: |
           image=$(kubectl -n $K8S_NAMESPACE get sts mgmds \

--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -560,15 +560,27 @@ jobs:
           echo "Captured cluster.log offset: $OFFSET"
           echo "$OFFSET" > /tmp/cluster-log-offset.txt
 
-      # --reuse-values is intentional — it mirrors what real users do.
-      # If the new chart's schema rejects values defaulted in 0.7.29,
-      # that is a real finding to surface, not paper over with --set.
+      # Re-supply the install's values on the upgrade rather than using
+      # `--reuse-values`. Per maintainer guidance, Hopsworks customers
+      # always pass their values files on every `helm upgrade` rather
+      # than relying on `--reuse-values`, so the test mirrors that
+      # flow. Practical effect: the new chart's `values.yaml` defaults
+      # are merged in (filling in any schema-required fields the OLD
+      # chart didn't ship — e.g. `meta.ddlMySQLd` added in HWORKS-2753),
+      # and the operator-supplied overlay + --set carry the
+      # cluster-shape and resource overrides forward.
       - name: Upgrade to new chart (PR head)
         run: |
           helm upgrade $RONDB_CLUSTER_NAME ./new-chart \
             --namespace=$K8S_NAMESPACE \
-            --reuse-values \
-            --wait --timeout=15m
+            --wait --timeout=15m \
+            --values ./old-chart/values/minikube/small.yaml \
+            --set staticCpuManagerPolicy=true \
+            --set clusterSize.minNumMySQLServers=1 \
+            --set clusterSize.maxNumMySQLServers=1 \
+            --set rondbConfig.TotalMemoryConfig=4096M \
+            --set resources.limits.memory.ndbmtdsMiB=5120 \
+            --set backups.enabled=false
 
       # A1: NDB Error 2305 = "arbitrator decided to shutdown this node".
       # The exact failure mode the pre-upgrade hook prevents.

--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -403,6 +403,13 @@ jobs:
       #     to succeed. 2048M would fail in startphase 0 with
       #     `error 2350: Invalid configuration received from
       #     Management Server`.
+      #   - `resources.limits.memory.ndbmtdsMiB=5120` raises the
+      #     ndbmtd container's cgroup memory limit from small.yaml's
+      #     default 3300 MiB. With TotalMemoryConfig=4096M, RonDB
+      #     auto-config plans ~3 GB of touched pages plus headroom,
+      #     which exceeds 3300 MiB and gets the pod OOM-killed (SIGKILL)
+      #     at startphase 0. 5120 mirrors what mini.yaml uses for the
+      #     same TotalMemoryConfig in benchmark-and-stability.
       #   - `backups.enabled=false` removes the rclone-listener
       #     sidecar; the OLD chart 0.7.29 defaults `backups.enabled:
       #     true` plus a hardcoded `aws-credentials` Secret reference
@@ -421,6 +428,7 @@ jobs:
             --set clusterSize.minNumMySQLServers=1 \
             --set clusterSize.maxNumMySQLServers=1 \
             --set rondbConfig.TotalMemoryConfig=4096M \
+            --set resources.limits.memory.ndbmtdsMiB=5120 \
             --set backups.enabled=false
 
       # Inline diagnostics on install failure. The install runs `helm
@@ -430,6 +438,21 @@ jobs:
       # the cross_version_logs artifact. Print pod state, events, and
       # the last lines of every container's current+previous log so
       # the failure root cause is visible inline.
+      #
+      # Each section answers a specific failure-mode question that
+      # would otherwise force you into the artifact:
+      #   pods / events / container logs — "what's RonDB itself saying?"
+      #   pod descriptions               — "was it OOMKilled? exit code?
+      #                                     signal? lastState reason?"
+      #   container resource limits      — "what cgroup ceiling did the
+      #                                     chart actually render? did
+      #                                     our --set overrides land?"
+      #   node state + top               — "is this node-OOM or
+      #                                     container-cgroup OOM? are we
+      #                                     near node MemoryPressure?"
+      #   helm get values                — "did the --set overrides
+      #                                     resolve to the values we
+      #                                     intended (typo check)?"
       - name: Diagnostics on install failure
         if: failure()
         run: |
@@ -440,6 +463,17 @@ jobs:
               | tail -n 30 || true
           echo "=== ndbmtd / mgmd / rdrs / mysqld container logs (last 50 lines each) ==="
           for pod in $(kubectl -n $K8S_NAMESPACE get pods -o jsonpath='{.items[*].metadata.name}'); do
+            # Init containers first — a pod stuck in Init:N/M (e.g. the
+            # wait-datanodes-dependency / mgmd-dependency-check chain on
+            # mysqlds-0) has its real failure narrative in init logs.
+            # `.spec.containers[*]` does not include init containers, so
+            # iterating it alone silently skips them.
+            for c in $(kubectl -n $K8S_NAMESPACE get pod "$pod" -o jsonpath='{.spec.initContainers[*].name}'); do
+              echo "--- $pod / $c (init, current) ---"
+              kubectl -n $K8S_NAMESPACE logs "$pod" -c "$c" --tail=50 2>&1 || true
+              echo "--- $pod / $c (init, previous) ---"
+              kubectl -n $K8S_NAMESPACE logs "$pod" -c "$c" --previous --tail=50 2>&1 || true
+            done
             for c in $(kubectl -n $K8S_NAMESPACE get pod "$pod" -o jsonpath='{.spec.containers[*].name}'); do
               echo "--- $pod / $c (current) ---"
               kubectl -n $K8S_NAMESPACE logs "$pod" -c "$c" --tail=50 2>&1 || true
@@ -447,6 +481,73 @@ jobs:
               kubectl -n $K8S_NAMESPACE logs "$pod" -c "$c" --previous --tail=50 2>&1 || true
             done
           done
+          echo "=== pod descriptions (lastState.terminated: reason, exitCode, signal) ==="
+          # `kubectl describe pod` prints `Last State: Terminated` with
+          # Reason / Exit Code / Signal / Started / Finished — the direct
+          # answer to "why did this container die" with no inference
+          # required (e.g. Reason=OOMKilled, ExitCode=137 makes
+          # cgroup-OOM unambiguous). Also includes the per-container
+          # `Limits:` block as the kubelet sees it.
+          kubectl -n $K8S_NAMESPACE describe pods || true
+          echo "=== container resource limits as rendered by the chart ==="
+          # Sanity-check that our `--set resources.limits.memory.*`
+          # overrides actually propagated through `helm install` to the
+          # live StatefulSet spec. A typo in the dotted path would
+          # silently no-op and let the cluster boot with whatever the
+          # overlay's default was — exactly the failure shape that
+          # produced the OOM-kill we just debugged.
+          for sts in $(kubectl -n $K8S_NAMESPACE get statefulset \
+                         -o jsonpath='{.items[*].metadata.name}'); do
+            echo "--- statefulset/$sts ---"
+            kubectl -n $K8S_NAMESPACE get statefulset "$sts" \
+              -o jsonpath='{range .spec.template.spec.containers[*]}{.name}: requests={.resources.requests} limits={.resources.limits}{"\n"}{end}' \
+              || true
+            echo
+          done
+          echo "=== node state (MemoryPressure, Allocatable vs Allocated) ==="
+          # Distinguishes container-cgroup OOM (one container killed,
+          # node healthy) from node-level memory exhaustion (node tainted
+          # MemoryPressure=True, multiple pods evicted). The Conditions
+          # block and the Allocated resources table at the bottom of
+          # `describe node` answer this in one screen.
+          kubectl describe nodes || true
+          echo "=== resource utilisation (only printed if metrics-server is up) ==="
+          kubectl top nodes 2>&1 || true
+          kubectl -n $K8S_NAMESPACE top pods 2>&1 || true
+          echo "=== helm release: resolved values (post --set) ==="
+          # `helm get values --all` shows the merged result of the
+          # default values.yaml + --values overlay + every --set, so a
+          # missing/typo'd override is visible at a glance.
+          helm get values $RONDB_CLUSTER_NAME -n $K8S_NAMESPACE --all || true
+          echo "=== helm release: history + status ==="
+          # Catches release-level failures where pod-side diagnostics
+          # are partial or empty: schema rejection that throws after
+          # some manifests have applied, post-render failures, hook
+          # job non-zero exits etc. `helm status` prints the LAST
+          # DEPLOYED stamp, deployed/failed marker, and any
+          # NOTES.txt-rendered tail; `helm history` shows whether the
+          # current revision was a successful deploy or a `failed` one.
+          helm history $RONDB_CLUSTER_NAME -n $K8S_NAMESPACE || true
+          helm status  $RONDB_CLUSTER_NAME -n $K8S_NAMESPACE || true
+          echo "=== persistent volume claims (binding state) ==="
+          # Unbound PVCs are a real minikube failure mode (storageClass
+          # naming drift, hostpath provisioner unhealthy, capacity
+          # exhausted). They surface here as `Pending` rather than
+          # anywhere in the per-pod logs.
+          kubectl -n $K8S_NAMESPACE get pvc -o wide || true
+          for pvc in $(kubectl -n $K8S_NAMESPACE get pvc \
+                         -o jsonpath='{range .items[?(@.status.phase!="Bound")]}{.metadata.name} {end}'); do
+            echo "--- pvc/$pvc (not Bound) ---"
+            kubectl -n $K8S_NAMESPACE describe pvc "$pvc" || true
+          done
+          echo "=== cluster.log tail (mgmd's authoritative cluster narrative) ==="
+          # mgmd's cluster.log records cluster-wide events that no
+          # per-container kubectl-logs view captures: data-node connect
+          # / disconnect, arbitrator decisions (Error 2305 candidates),
+          # GCP rounds, schema-op outcomes. If MGMd itself is down the
+          # exec fails and the `|| true` keeps the step going.
+          kubectl -n $K8S_NAMESPACE exec mgmds-0 -c mgmd -- \
+              tail -n 200 /srv/hops/mysql-cluster/log/cluster.log 2>&1 || true
 
       # Snapshot the current cluster.log line count so the post-upgrade
       # assertion (A2) only inspects lines emitted during the upgrade

--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -610,9 +610,58 @@ jobs:
               tail -n +$((OFFSET + 1)) /srv/hops/mysql-cluster/log/cluster.log)
           if echo "$slice" | grep -F "Start phase 0 completed (system restart)"; then
             echo "::error::cluster.log shows a system restart during the upgrade window"
+            # Dump the full upgrade-window slice so the diagnosis is visible
+            # inline rather than buried in the cross_version_logs artifact.
+            # The slice + context covers data-node connect/disconnect events,
+            # MGMd restart timing, and arbitration decisions — exactly what's
+            # needed to tell C1 (parallel rolling) from C2 (hook-induced
+            # shutdown) from C3 (protocol kick-off).
+            echo "=== full cluster.log slice (lines after $OFFSET) ==="
+            echo "$slice"
             exit 1
           fi
           echo "No system-restart events in upgrade-window slice (lines after $OFFSET)."
+
+      # On any assertion failure, print pod-level evidence so the diagnosis
+      # is visible inline rather than requiring the cross_version_logs
+      # artifact download. Specifically: ndbmtd pod restart history (from
+      # `kubectl describe pod` lastState + container restart counts), recent
+      # events filtered to data-node pods, and each ndbmtd's previous-pod
+      # logs (where the last ~50 lines before the kill live).
+      - name: Diagnostics on upgrade/assertion failure
+        if: failure()
+        run: |
+          echo "=== ndbmtd pod descriptions (restart count, lastState, terminated reason) ==="
+          for pod in $(kubectl -n $K8S_NAMESPACE get pods -l rondbService=ndbmtd \
+                         -o jsonpath='{.items[*].metadata.name}'); do
+            echo "--- $pod ---"
+            kubectl -n $K8S_NAMESPACE describe pod "$pod" | grep -E \
+              'Restart Count|Last State|Reason|Exit Code|Started:|Finished:|^Events:|^\s+(Normal|Warning)' || true
+          done
+          echo "=== events filtered to ndbmtd pods (creation order) ==="
+          kubectl -n $K8S_NAMESPACE get events --sort-by='.metadata.creationTimestamp' \
+            --field-selector involvedObject.kind=Pod 2>&1 \
+            | grep -E 'node-group|ndbmtd' || true
+          echo "=== ndbmtd previous-pod logs (last 80 lines, the dying breath of the OLD-image pod) ==="
+          for pod in $(kubectl -n $K8S_NAMESPACE get pods -l rondbService=ndbmtd \
+                         -o jsonpath='{.items[*].metadata.name}'); do
+            echo "--- $pod / ndbmtd (previous) ---"
+            kubectl -n $K8S_NAMESPACE logs "$pod" -c ndbmtd --previous --tail=80 2>&1 || true
+          done
+          echo "=== ndbmtd current-pod logs (last 80 lines, the NEW-image boot story) ==="
+          for pod in $(kubectl -n $K8S_NAMESPACE get pods -l rondbService=ndbmtd \
+                         -o jsonpath='{.items[*].metadata.name}'); do
+            echo "--- $pod / ndbmtd (current) ---"
+            kubectl -n $K8S_NAMESPACE logs "$pod" -c ndbmtd --tail=80 2>&1 || true
+          done
+          echo "=== StatefulSet update spec (rendered podManagementPolicy + updateStrategy) ==="
+          for sts in $(kubectl -n $K8S_NAMESPACE get statefulset \
+                         -o jsonpath='{.items[*].metadata.name}'); do
+            echo "--- $sts ---"
+            kubectl -n $K8S_NAMESPACE get statefulset "$sts" \
+              -o jsonpath='podManagementPolicy={.spec.podManagementPolicy} updateStrategy={.spec.updateStrategy}{"\n"}' \
+              2>&1 || true
+          done
 
       # A3: Sanity check that the upgrade actually touched MGMd's image.
       # If --reuse-values produced a no-op or the hook somehow blocked

--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -330,3 +330,148 @@ jobs:
         run: |
           source ./test_scripts/minio.env
           kubectl delete namespace $MINIO_TENANT_NAMESPACE --timeout=50s || true
+
+  # Cross-version chart upgrade test for the pre-upgrade MGMd hook
+  # (templates/mgmd_pre_upgrade.yaml). Installs the chart at branch-0.7
+  # (which pre-dates the hook) and upgrades to the PR head, then asserts
+  # the upgrade did not trigger arbitration loss (NDB Error 2305) or a
+  # whole-cluster system restart. Requested by maintainer in PR #170 review
+  # comment 3161156784.
+  upgrade-cross-version:
+    needs: [benchmark-and-stability]
+    name: Cross-version chart upgrade (no arbitration loss)
+    if: github.repository == 'logicalclocks/rondb-helm'
+    concurrency:
+      group: self-hosted-runner
+      cancel-in-progress: false
+    runs-on: [self-hosted, ARM64]
+    env:
+      K8S_NAMESPACE: rondb-helm-upgrade-${{ github.run_id }}-${{ github.run_attempt }}
+      RONDB_CLUSTER_NAME: my-rondb
+    steps:
+      - name: Checkout new chart (PR head)
+        uses: actions/checkout@v4
+        with:
+          path: new-chart
+
+      - name: Checkout old chart (branch-0.7, chart 0.7.29 / app 24.10.19)
+        uses: actions/checkout@v4
+        with:
+          repository: logicalclocks/rondb-helm
+          ref: branch-0.7
+          path: old-chart
+
+      - name: Check kubectl (should be Minikube)
+        run: |
+          kubectl version --client
+          kubectl get nodes
+
+      - name: Pre-cleanup stale resources
+        run: |
+          # Delete any leftover rondb-helm namespaces from previous cancelled/failed runs
+          for ns in $(kubectl get namespaces -o name | grep 'namespace/rondb-helm-' | cut -d/ -f2); do
+            if [ "$ns" != "$K8S_NAMESPACE" ]; then
+              echo "Cleaning up stale namespace: $ns"
+              helm delete --namespace="$ns" my-rondb 2>/dev/null || true
+              kubectl delete namespace "$ns" --timeout=120s 2>/dev/null || true
+            fi
+          done
+          kubectl delete priorityclass rondb-high-priority 2>/dev/null || true
+
+      # Install the OLD chart. Sized down so the test fits the minikube
+      # runner; one node-group is enough to exercise arbitration because
+      # both old and new values.yaml default to activeDataReplicas: 2.
+      - name: Install old chart (0.7.29 / 24.10.19)
+        run: |
+          helm install $RONDB_CLUSTER_NAME ./old-chart \
+            --namespace=$K8S_NAMESPACE \
+            --create-namespace \
+            --wait --timeout=15m \
+            --set staticCpuManagerPolicy=true \
+            --set clusterSize.numNodeGroups=1 \
+            --set clusterSize.minNumMySQLServers=1 \
+            --set clusterSize.maxNumMySQLServers=1 \
+            --set clusterSize.minNumRdrs=1 \
+            --set clusterSize.maxNumRdrs=1 \
+            --set rondbConfig.TotalMemoryConfig=2048M
+
+      # Snapshot the current cluster.log line count so the post-upgrade
+      # assertion (A2) only inspects lines emitted during the upgrade
+      # window — the install itself logs "Start phase 0 completed
+      # (system restart)" as part of normal startup.
+      - name: Snapshot cluster.log offset
+        run: |
+          OFFSET=$(kubectl -n $K8S_NAMESPACE exec mgmds-0 -c mgmd -- \
+              wc -l /srv/hops/mysql-cluster/log/cluster.log | awk '{print $1}')
+          echo "Captured cluster.log offset: $OFFSET"
+          echo "$OFFSET" > /tmp/cluster-log-offset.txt
+
+      # --reuse-values is intentional — it mirrors what real users do.
+      # If the new chart's schema rejects values defaulted in 0.7.29,
+      # that is a real finding to surface, not paper over with --set.
+      - name: Upgrade to new chart (PR head)
+        run: |
+          helm upgrade $RONDB_CLUSTER_NAME ./new-chart \
+            --namespace=$K8S_NAMESPACE \
+            --reuse-values \
+            --wait --timeout=15m
+
+      # A1: NDB Error 2305 = "arbitrator decided to shutdown this node".
+      # The exact failure mode the pre-upgrade hook prevents.
+      - name: Assert no arbitration loss (Error 2305)
+        run: |
+          fail=0
+          for pod in $(kubectl -n $K8S_NAMESPACE get pods -l rondbService=ndbmtd \
+                         -o jsonpath='{.items[*].metadata.name}'); do
+            echo "Checking $pod for Error 2305"
+            if kubectl -n $K8S_NAMESPACE exec "$pod" -c ndbmtd -- \
+                bash -c 'grep -l "Error: 2305" /srv/hops/mysql-cluster/log/ndb_*_error.log 2>/dev/null'; then
+              echo "::error::Pod $pod logged NDB Error 2305 (arbitration loss) during upgrade"
+              kubectl -n $K8S_NAMESPACE exec "$pod" -c ndbmtd -- \
+                bash -c 'grep -A2 -B2 "Error: 2305" /srv/hops/mysql-cluster/log/ndb_*_error.log' || true
+              fail=1
+            fi
+          done
+          exit $fail
+
+      # A2: A "system restart" line means every data node was down
+      # simultaneously. The slice starts at the snapshotted offset so we
+      # ignore the initial install's own startup messages.
+      - name: Assert no system restart in upgrade window
+        run: |
+          OFFSET=$(cat /tmp/cluster-log-offset.txt)
+          slice=$(kubectl -n $K8S_NAMESPACE exec mgmds-0 -c mgmd -- \
+              tail -n +$((OFFSET + 1)) /srv/hops/mysql-cluster/log/cluster.log)
+          if echo "$slice" | grep -F "Start phase 0 completed (system restart)"; then
+            echo "::error::cluster.log shows a system restart during the upgrade window"
+            exit 1
+          fi
+          echo "No system-restart events in upgrade-window slice (lines after $OFFSET)."
+
+      # A3: Sanity check that the upgrade actually touched MGMd's image.
+      # If --reuse-values produced a no-op or the hook somehow blocked
+      # the spec change, A1/A2 might pass for the wrong reason.
+      - name: Assert MGMd image was upgraded
+        run: |
+          image=$(kubectl -n $K8S_NAMESPACE get sts mgmds \
+              -o jsonpath='{.spec.template.spec.containers[?(@.name=="mgmd")].image}')
+          echo "MGMd image after upgrade: $image"
+          if [[ "$image" == *":24.10.19" ]]; then
+            echo "::error::MGMd image still at 24.10.19 — upgrade did not roll the StatefulSet"
+            exit 1
+          fi
+
+      - name: Collect logs
+        if: always()
+        uses: ./new-chart/.github/actions/collect_logs
+        with:
+          namespace: ${{ env.K8S_NAMESPACE }}
+          folder_name: cross_version_logs
+
+      - name: Remove cluster
+        if: always()
+        uses: ./new-chart/.github/actions/remove_cluster
+        timeout-minutes: 4
+        with:
+          namespace: ${{ env.K8S_NAMESPACE }}
+          helm_chart: ${{ env.RONDB_CLUSTER_NAME }}

--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -395,7 +395,14 @@ jobs:
       #     overrides small.yaml's 2 — one mysqld is enough to
       #     exercise the upgrade path and saves a pod's worth of
       #     resources on the runner.
-      #   - `rondbConfig.TotalMemoryConfig=2048M` per the test spec.
+      #   - `rondbConfig.TotalMemoryConfig=4096M` matches the
+      #     known-good value benchmark-and-stability uses. The 1x2
+      #     topology with small.yaml's TransactionMemory=300M /
+      #     SharedGlobalMemory=300M reserves ~3 GB before DataMemory;
+      #     RonDB requires >=3589 MB total for AutomaticMemoryConfig
+      #     to succeed. 2048M would fail in startphase 0 with
+      #     `error 2350: Invalid configuration received from
+      #     Management Server`.
       #   - `backups.enabled=false` removes the rclone-listener
       #     sidecar; the OLD chart 0.7.29 defaults `backups.enabled:
       #     true` plus a hardcoded `aws-credentials` Secret reference
@@ -413,8 +420,33 @@ jobs:
             --set staticCpuManagerPolicy=true \
             --set clusterSize.minNumMySQLServers=1 \
             --set clusterSize.maxNumMySQLServers=1 \
-            --set rondbConfig.TotalMemoryConfig=2048M \
+            --set rondbConfig.TotalMemoryConfig=4096M \
             --set backups.enabled=false
+
+      # Inline diagnostics on install failure. The install runs `helm
+      # --wait` (silent until success or timeout), so without these
+      # the only signal a future failure leaves in the runner log is
+      # `context deadline exceeded` — debugging requires downloading
+      # the cross_version_logs artifact. Print pod state, events, and
+      # the last lines of every container's current+previous log so
+      # the failure root cause is visible inline.
+      - name: Diagnostics on install failure
+        if: failure()
+        run: |
+          echo "=== pods ==="
+          kubectl -n $K8S_NAMESPACE get pods -o wide || true
+          echo "=== events (last 30, newest first) ==="
+          kubectl -n $K8S_NAMESPACE get events --sort-by='.metadata.creationTimestamp' \
+              | tail -n 30 || true
+          echo "=== ndbmtd / mgmd / rdrs / mysqld container logs (last 50 lines each) ==="
+          for pod in $(kubectl -n $K8S_NAMESPACE get pods -o jsonpath='{.items[*].metadata.name}'); do
+            for c in $(kubectl -n $K8S_NAMESPACE get pod "$pod" -o jsonpath='{.spec.containers[*].name}'); do
+              echo "--- $pod / $c (current) ---"
+              kubectl -n $K8S_NAMESPACE logs "$pod" -c "$c" --tail=50 2>&1 || true
+              echo "--- $pod / $c (previous) ---"
+              kubectl -n $K8S_NAMESPACE logs "$pod" -c "$c" --previous --tail=50 2>&1 || true
+            done
+          done
 
       # Snapshot the current cluster.log line count so the post-upgrade
       # assertion (A2) only inspects lines emitted during the upgrade

--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -561,7 +561,7 @@ jobs:
           if echo "$slice" | grep -E 'Start node: [0-9]+ using system restart'; then
             echo "::error::cluster.log shows a true system restart (lost quorum) during the upgrade window"
             # Full slice for inline diagnosis (parallel rolling vs.
-            # hook-induced shutdown vs. protocol kick-off).
+            # hook-induced shutdown).
             echo "=== full cluster.log slice (lines after $OFFSET) ==="
             echo "$slice"
             exit 1

--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -587,8 +587,17 @@ jobs:
       - name: Assert no arbitration loss (Error 2305)
         run: |
           fail=0
-          for pod in $(kubectl -n $K8S_NAMESPACE get pods -l rondbService=ndbmtd \
-                         -o jsonpath='{.items[*].metadata.name}'); do
+          # Refuse-to-pass if the label selector matches zero pods. Without
+          # this guard, a future chart rename of the `rondbService` label
+          # value would silently iterate zero pods and let A1 pass on a
+          # cluster that hasn't actually been checked.
+          pods=$(kubectl -n $K8S_NAMESPACE get pods -l rondbService=ndbmtd \
+                   -o jsonpath='{.items[*].metadata.name}')
+          if [ -z "$pods" ]; then
+            echo "::error::No pods found with label rondbService=ndbmtd — chart may have renamed the label"
+            exit 1
+          fi
+          for pod in $pods; do
             echo "Checking $pod for Error 2305"
             if kubectl -n $K8S_NAMESPACE exec "$pod" -c ndbmtd -- \
                 bash -c 'grep -l "Error: 2305" /srv/hops/mysql-cluster/log/ndb_*_error.log 2>/dev/null'; then
@@ -680,8 +689,14 @@ jobs:
           done
 
       # A3: Sanity check that the upgrade actually touched MGMd's image.
-      # If --reuse-values produced a no-op or the hook somehow blocked
+      # If the values overlay produced a no-op or the hook somehow blocked
       # the spec change, A1/A2 might pass for the wrong reason.
+      #
+      # The hardcoded `:24.10.19` is paired with the OLD-chart pin in the
+      # `Checkout old chart` step (`ref: branch-0.7`, which ships RonDB
+      # 24.10.19). If that pin ever moves to a different OLD-chart
+      # branch, update the version string below so this assertion stays
+      # meaningful — otherwise it will silently pass on any image.
       - name: Assert MGMd image was upgraded
         run: |
           image=$(kubectl -n $K8S_NAMESPACE get sts mgmds \

--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -378,17 +378,26 @@ jobs:
           done
           kubectl delete priorityclass rondb-high-priority 2>/dev/null || true
 
-      # Install the OLD chart. Sized down so the test fits the minikube
-      # runner; one node-group is enough to exercise arbitration because
-      # both old and new values.yaml default to activeDataReplicas: 2.
+      # Install the OLD chart. We overlay the OLD chart's
+      # values/minikube/mini.yaml for resource-request sizing (the same
+      # overlay that benchmark-and-stability uses) — the chart's default
+      # values.yaml has per-pod memory limits and PV requests
+      # (ndbmtdsMiB=5000, ndbmtdGiB=30, redoLogGiB=4, …) that are sized
+      # for production and don't fit the ARM64 minikube runner. The
+      # `--set clusterSize.*` overrides are applied after the values
+      # overlay; in particular `activeDataReplicas=2` is needed because
+      # mini.yaml defaults to 1, and the arbitration scenario A1/A2
+      # asserts only have meaning with at least 2 data-node replicas.
       - name: Install old chart (0.7.29 / 24.10.19)
         run: |
           helm install $RONDB_CLUSTER_NAME ./old-chart \
             --namespace=$K8S_NAMESPACE \
             --create-namespace \
             --wait --timeout=15m \
+            --values ./old-chart/values/minikube/mini.yaml \
             --set staticCpuManagerPolicy=true \
             --set clusterSize.numNodeGroups=1 \
+            --set clusterSize.activeDataReplicas=2 \
             --set clusterSize.minNumMySQLServers=1 \
             --set clusterSize.maxNumMySQLServers=1 \
             --set clusterSize.minNumRdrs=1 \

--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -603,13 +603,29 @@ jobs:
       # A2: A "system restart" line means every data node was down
       # simultaneously. The slice starts at the snapshotted offset so we
       # ignore the initial install's own startup messages.
+      #
+      # Match on the explicit `Start node: N using system restart`
+      # decision line rather than on the `Start phase 0 completed
+      # (system restart)` placeholder. Phases 0 and 1 are logged with
+      # the `(system restart)` tag on *every* ndbmtd boot — including
+      # routine node-restarts during a rolling upgrade — because the
+      # restart-type decision is made after phase 1. By phase 2 the
+      # log line transitions to `(node restart)` if MGMd reports a
+      # live peer. Grepping the placeholder produces a false positive
+      # on every successful rolling upgrade.
+      #
+      # `Start node: <id> using system restart` is logged only when
+      # MGMd has decided the booting node must do a true system
+      # restart (no live peer at decision time, i.e. the cluster lost
+      # quorum). That is exactly the failure mode this assertion
+      # exists to catch.
       - name: Assert no system restart in upgrade window
         run: |
           OFFSET=$(cat /tmp/cluster-log-offset.txt)
           slice=$(kubectl -n $K8S_NAMESPACE exec mgmds-0 -c mgmd -- \
               tail -n +$((OFFSET + 1)) /srv/hops/mysql-cluster/log/cluster.log)
-          if echo "$slice" | grep -F "Start phase 0 completed (system restart)"; then
-            echo "::error::cluster.log shows a system restart during the upgrade window"
+          if echo "$slice" | grep -E 'Start node: [0-9]+ using system restart'; then
+            echo "::error::cluster.log shows a true system restart (lost quorum) during the upgrade window"
             # Dump the full upgrade-window slice so the diagnosis is visible
             # inline rather than buried in the cross_version_logs artifact.
             # The slice + context covers data-node connect/disconnect events,
@@ -620,7 +636,7 @@ jobs:
             echo "$slice"
             exit 1
           fi
-          echo "No system-restart events in upgrade-window slice (lines after $OFFSET)."
+          echo "No true system-restart decisions in upgrade-window slice (lines after $OFFSET)."
 
       # On any assertion failure, print pod-level evidence so the diagnosis
       # is visible inline rather than requiring the cross_version_logs

--- a/templates/mgmd.yaml
+++ b/templates/mgmd.yaml
@@ -1,5 +1,7 @@
 # Copyright (c) 2024-2026 Hopsworks AB. All rights reserved.
 
+{{- /* Wrapped in a named template so the pre-upgrade hook (mgmd_pre_upgrade.yaml) can apply the same manifest set the chart's main apply produces. */ -}}
+{{- define "rondb.mgmdManifests" -}}
 {{- if not (include "rondb.isExternallyManaged" .) }}
 apiVersion: apps/v1
 kind: StatefulSet
@@ -147,3 +149,5 @@ spec:
   type: ExternalName
   externalName: {{ .Values.global._hopsworks.externalServices.rondb.mgmdHostname }}
 {{- end -}}
+{{- end -}}
+{{ include "rondb.mgmdManifests" . }}

--- a/templates/mgmd_pre_upgrade.yaml
+++ b/templates/mgmd_pre_upgrade.yaml
@@ -83,6 +83,13 @@ rules:
   resources: ["statefulsets"]
   verbs: ["get", "patch", "watch"]
   resourceNames: [{{ .Values.meta.mgmd.statefulSetName | quote }}]
+# `kubectl rollout status` uses an informer-watcher that calls list
+# before watch. Kubernetes RBAC disallows combining `list` with
+# `resourceNames`, so this rule is broader than the one above and
+# unavoidably grants list on all statefulsets in the namespace.
+- apiGroups: ["apps"]
+  resources: ["statefulsets"]
+  verbs: ["list"]
 - apiGroups: ["apps"]
   resources: ["statefulsets/status"]
   verbs: ["get", "watch"]

--- a/templates/mgmd_pre_upgrade.yaml
+++ b/templates/mgmd_pre_upgrade.yaml
@@ -258,8 +258,17 @@ spec:
           # time. Applying the whole rendered manifest covers every
           # field — nodeSelector, tolerations, resources, probes,
           # sidecars, ConfigMap data — not just image and configIniHash.
-          log "Applying target MGMd manifests (server-side, field-manager=helm)"
-          kubectl apply -n "$NAMESPACE" --server-side --field-manager=helm \
+          #
+          # `--force-conflicts` is required because the existing
+          # mgmds/mgmd-configs/headless-mgmds resources may have been
+          # created by Helm 3 client-side apply (no SSA managedFields
+          # tracking), or by a different field-manager. SSA without
+          # force rejects the apply on conflict; with force the hook
+          # takes ownership of the fields it sets. Same content as the
+          # main apply will write, so this is the source-of-truth move
+          # rather than a hostile takeover.
+          log "Applying target MGMd manifests (server-side, field-manager=helm, force-conflicts)"
+          kubectl apply -n "$NAMESPACE" --server-side --field-manager=helm --force-conflicts \
               -f /etc/rondb-config/mgmd-manifests.yaml
 
           log "Waiting for $STS_NAME rollout to converge (timeout: $ROLLOUT_TIMEOUT)"

--- a/templates/mgmd_pre_upgrade.yaml
+++ b/templates/mgmd_pre_upgrade.yaml
@@ -198,8 +198,8 @@ spec:
           # sidecars) that the full apply now covers. Always apply —
           # client-side apply is a no-op when nothing differs, and
           # rollout-status returns immediately if already converged.
-          log "Applying target MGMd manifests (client-side, field-manager=helm)"
-          kubectl apply -n "$NAMESPACE" --field-manager=helm \
+          log "Applying target MGMd manifests (client-side apply)"
+          kubectl apply -n "$NAMESPACE" \
               -f /etc/rondb-config/mgmd-manifests.yaml
 
           # `kubectl rollout status` returns when the pod is Ready,

--- a/templates/mgmd_pre_upgrade.yaml
+++ b/templates/mgmd_pre_upgrade.yaml
@@ -50,6 +50,14 @@ metadata:
   annotations:
     "helm.sh/hook": pre-upgrade
     "helm.sh/hook-weight": "-20"
+    # Clean up after the hook succeeds. Otherwise the Job's failed
+    # backoff-retry pods linger in the namespace (the Job's name
+    # includes `.Release.Revision`, so `before-hook-creation` alone
+    # never matches a previous-revision resource), tripping the
+    # stability check (`.github/test_deploy_stability.sh`) and the
+    # `kubectl get all`-driven wait loop in
+    # `.github/actions/remove_cluster`.
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
 data:
   config.ini: |
 {{ tpl (.Files.Get "files/configs/config.ini") . | indent 4 }}
@@ -62,6 +70,7 @@ metadata:
   annotations:
     "helm.sh/hook": pre-upgrade
     "helm.sh/hook-weight": "-20"
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
@@ -71,6 +80,7 @@ metadata:
   annotations:
     "helm.sh/hook": pre-upgrade
     "helm.sh/hook-weight": "-20"
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
 rules:
 - apiGroups: ["apps"]
   resources: ["statefulsets"]
@@ -96,6 +106,7 @@ metadata:
   annotations:
     "helm.sh/hook": pre-upgrade
     "helm.sh/hook-weight": "-20"
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
 subjects:
 - kind: ServiceAccount
   name: rondb-mgmd-pre-upgrade
@@ -115,6 +126,12 @@ metadata:
     # Hook-weight is set high enough that this hook runs after any other
     # pre-upgrade hooks the chart defines (e.g. mysql privilege migration).
     "helm.sh/hook-weight": "10"
+    # `hook-succeeded` is required: the Job has `backoffLimit: 3`, so a
+    # transient first-attempt failure (e.g. `kubectl rollout status`
+    # exceeding ROLLOUT_TIMEOUT) is recovered by a retry pod, but the
+    # Failed pod from the first attempt would otherwise persist in the
+    # namespace and confuse downstream stability/cleanup checks.
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
 spec:
   backoffLimit: 3
   template:

--- a/templates/mgmd_pre_upgrade.yaml
+++ b/templates/mgmd_pre_upgrade.yaml
@@ -45,19 +45,17 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: rondb-mgmd-pre-upgrade-config-{{ .Release.Revision }}
+  # Stable name (no Release.Revision suffix) so `before-hook-creation`
+  # actually matches and replaces the previous revision's ConfigMap.
+  # Argo CD's hook lifecycle treats non-Job hooks as "succeeded" the
+  # moment they're applied, so `hook-succeeded` here would let Argo
+  # delete this ConfigMap before the wave-10 Job mounts it.
+  name: rondb-mgmd-pre-upgrade-config
   namespace: {{ .Release.Namespace }}
   annotations:
     "helm.sh/hook": pre-upgrade
     "helm.sh/hook-weight": "-20"
-    # Clean up after the hook succeeds. Otherwise the Job's failed
-    # backoff-retry pods linger in the namespace (the Job's name
-    # includes `.Release.Revision`, so `before-hook-creation` alone
-    # never matches a previous-revision resource), tripping the
-    # stability check (`.github/test_deploy_stability.sh`) and the
-    # `kubectl get all`-driven wait loop in
-    # `.github/actions/remove_cluster`.
-    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+    "helm.sh/hook-delete-policy": before-hook-creation
 data:
   config.ini: |
 {{ tpl (.Files.Get "files/configs/config.ini") . | indent 4 }}
@@ -70,7 +68,11 @@ metadata:
   annotations:
     "helm.sh/hook": pre-upgrade
     "helm.sh/hook-weight": "-20"
-    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+    # `hook-succeeded` would let Argo CD remove this support resource
+    # before the wave-10 Job that depends on it runs, so we keep
+    # `before-hook-creation` only. Stable names + before-hook-creation
+    # give us idempotent re-creation without the deletion race.
+    "helm.sh/hook-delete-policy": before-hook-creation
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
@@ -80,7 +82,7 @@ metadata:
   annotations:
     "helm.sh/hook": pre-upgrade
     "helm.sh/hook-weight": "-20"
-    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+    "helm.sh/hook-delete-policy": before-hook-creation
 rules:
 - apiGroups: ["apps"]
   resources: ["statefulsets"]
@@ -106,7 +108,7 @@ metadata:
   annotations:
     "helm.sh/hook": pre-upgrade
     "helm.sh/hook-weight": "-20"
-    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+    "helm.sh/hook-delete-policy": before-hook-creation
 subjects:
 - kind: ServiceAccount
   name: rondb-mgmd-pre-upgrade
@@ -286,5 +288,5 @@ spec:
       volumes:
       - name: rendered-config
         configMap:
-          name: rondb-mgmd-pre-upgrade-config-{{ .Release.Revision }}
+          name: rondb-mgmd-pre-upgrade-config
 {{- end }}

--- a/templates/mgmd_pre_upgrade.yaml
+++ b/templates/mgmd_pre_upgrade.yaml
@@ -137,11 +137,11 @@ spec:
         - name: NEW_CONFIG_INI_HASH
           value: {{ include "rondb.configIniHash" $ | quote }}
         - name: ROLLOUT_TIMEOUT
-          value: "10m"
+          value: "3m"
         - name: HEALTHCHECK_RETRIES
           value: "30"
         - name: HEALTHCHECK_INTERVAL_SECONDS
-          value: "5"
+          value: "2"
         volumeMounts:
         - name: rendered-config
           mountPath: /etc/rondb-config
@@ -152,48 +152,72 @@ spec:
         - |
           set -euo pipefail
 
-          echo "[mgmd-pre-upgrade] target image:        $NEW_IMAGE"
-          echo "[mgmd-pre-upgrade] target configIniHash: $NEW_CONFIG_INI_HASH"
+          log() { echo "[mgmd-pre-upgrade] $*"; }
 
-          echo "[mgmd-pre-upgrade] Updating mgmd-configs ConfigMap to new config.ini"
-          kubectl get configmap mgmd-configs -n "$NAMESPACE" -o json \
-            | jq --rawfile cfg /etc/rondb-config/config.ini '.data["config.ini"] = $cfg' \
-            | kubectl apply -n "$NAMESPACE" -f -
+          log "target image:           $NEW_IMAGE"
+          log "target configIniHash:   $NEW_CONFIG_INI_HASH"
+          log "statefulset:            $STS_NAME"
+          log "namespace:              $NAMESPACE"
 
-          echo "[mgmd-pre-upgrade] Patching $STS_NAME pod template (image + configIniHash)"
-          kubectl patch statefulset "$STS_NAME" -n "$NAMESPACE" --type=strategic -p "$(cat <<EOF
-          {
-            "spec": {
-              "template": {
-                "metadata": {
-                  "annotations": {
-                    "configIniHash": "$NEW_CONFIG_INI_HASH"
-                  }
-                },
-                "spec": {
-                  "containers": [
-                    {"name": "mgmd", "image": "$NEW_IMAGE"}
-                  ]
-                }
-              }
-            }
-          }
-          EOF
-          )"
+          # Fast-path: if the StatefulSet's pod template already matches the
+          # target image and configIniHash, there is no roll to wait for. We
+          # only verify MGMd is healthy and exit. This is the common case for
+          # upgrades that do not touch MGMd (e.g. scaling-only upgrades).
+          live_image=$(kubectl get statefulset "$STS_NAME" -n "$NAMESPACE" \
+              -o jsonpath='{.spec.template.spec.containers[?(@.name=="mgmd")].image}' \
+              2>/dev/null || echo "")
+          live_hash=$(kubectl get statefulset "$STS_NAME" -n "$NAMESPACE" \
+              -o jsonpath='{.spec.template.metadata.annotations.configIniHash}' \
+              2>/dev/null || echo "")
+          log "live image:             $live_image"
+          log "live configIniHash:     $live_hash"
 
-          echo "[mgmd-pre-upgrade] Waiting for $STS_NAME rollout (timeout: $ROLLOUT_TIMEOUT)"
-          kubectl rollout status statefulset/"$STS_NAME" -n "$NAMESPACE" --timeout="$ROLLOUT_TIMEOUT"
+          needs_patch=0
+          [ "$live_image" = "$NEW_IMAGE" ] || needs_patch=1
+          [ "$live_hash"  = "$NEW_CONFIG_INI_HASH" ] || needs_patch=1
 
-          echo "[mgmd-pre-upgrade] Verifying MGMd is serving (ndb_mgm -e show)"
+          if [ "$needs_patch" -eq 1 ]; then
+            log "Updating mgmd-configs ConfigMap to new config.ini"
+            kubectl get configmap mgmd-configs -n "$NAMESPACE" -o json \
+              | jq --rawfile cfg /etc/rondb-config/config.ini '.data["config.ini"] = $cfg' \
+              | kubectl apply -n "$NAMESPACE" -f -
+
+            log "Patching $STS_NAME pod template (image + configIniHash)"
+            patch_json=$(jq -n \
+                --arg image "$NEW_IMAGE" \
+                --arg hash "$NEW_CONFIG_INI_HASH" \
+                '{
+                   spec: {
+                     template: {
+                       metadata: { annotations: { configIniHash: $hash } },
+                       spec: { containers: [ { name: "mgmd", image: $image } ] }
+                     }
+                   }
+                 }')
+            kubectl patch statefulset "$STS_NAME" -n "$NAMESPACE" \
+                --type=strategic -p "$patch_json"
+
+            log "Waiting for $STS_NAME rollout (timeout: $ROLLOUT_TIMEOUT)"
+            kubectl rollout status statefulset/"$STS_NAME" -n "$NAMESPACE" \
+                --timeout="$ROLLOUT_TIMEOUT"
+          else
+            log "MGMd already at target image and configIniHash; skipping patch + rollout"
+          fi
+
+          log "Verifying MGMd is serving (ndb_mgm -e show)"
           for attempt in $(seq 1 "$HEALTHCHECK_RETRIES"); do
             if kubectl exec -n "$NAMESPACE" mgmds-0 -- ndb_mgm -e show >/dev/null 2>&1; then
-              echo "[mgmd-pre-upgrade] MGMd healthy after $attempt attempt(s); upgrade may proceed"
+              log "MGMd healthy after $attempt attempt(s); upgrade may proceed"
               exit 0
             fi
-            echo "[mgmd-pre-upgrade] attempt $attempt/$HEALTHCHECK_RETRIES: MGMd not yet serving, sleeping ${HEALTHCHECK_INTERVAL_SECONDS}s"
+            log "attempt $attempt/$HEALTHCHECK_RETRIES: MGMd not yet serving, sleeping ${HEALTHCHECK_INTERVAL_SECONDS}s"
             sleep "$HEALTHCHECK_INTERVAL_SECONDS"
           done
-          echo "[mgmd-pre-upgrade] MGMd did not become healthy within timeout" >&2
+
+          log "MGMd did not become healthy within timeout"
+          log "--- final diagnostics ---"
+          kubectl get pods -n "$NAMESPACE" -l rondbService=mgmd -o wide || true
+          kubectl describe statefulset "$STS_NAME" -n "$NAMESPACE" || true
           exit 1
       volumes:
       - name: rendered-config

--- a/templates/mgmd_pre_upgrade.yaml
+++ b/templates/mgmd_pre_upgrade.yaml
@@ -15,7 +15,7 @@
   This hook runs before the main upgrade applies any other manifest. It
   applies the full target MGMd manifest set (StatefulSet, mgmd-configs
   ConfigMap, headless Service — the same set the chart's main apply
-  would write) using server-side apply with field-manager=helm. When
+  would write) using client-side apply with field-manager=helm. When
   the main upgrade then runs, it sees no diff against the hook-applied
   state and does not roll MGMd a second time. The rest of the rollout
   proceeds with a stable, healthy primary arbitrator.
@@ -66,9 +66,9 @@ metadata:
 data:
   # The full MGMd manifest set (StatefulSet + mgmd-configs ConfigMap +
   # headless Service) rendered with this release's values. The hook Job
-  # mounts this file and applies it server-side. Keep in sync via the
-  # `rondb.mgmdManifests` named template — the chart's main apply
-  # (templates/mgmd.yaml) renders the same definition.
+  # mounts this file and applies it via client-side `kubectl apply`.
+  # Keep in sync via the `rondb.mgmdManifests` named template — the
+  # chart's main apply (templates/mgmd.yaml) renders the same definition.
   mgmd-manifests.yaml: |
 {{ include "rondb.mgmdManifests" . | indent 4 }}
 ---
@@ -216,31 +216,24 @@ spec:
           # changing would slip past such a check and let Helm's main
           # apply roll MGMd a second time — exactly the silent-gap class
           # of bug the full-apply rewrite exists to close. Instead we
-          # always apply: server-side apply against an already-correct
-          # live state is essentially a no-op (records co-ownership; no
-          # field change), and `kubectl rollout status` returns
-          # immediately on a converged StatefulSet. Steady-state Argo
-          # syncs incur ~1-2 seconds of API traffic per sync — an
+          # always apply: client-side apply against an already-correct
+          # live state is essentially a no-op (kubectl computes the diff
+          # and finds none; no API write), and `kubectl rollout status`
+          # returns immediately on a converged StatefulSet. Steady-state
+          # Argo syncs incur ~1-2 seconds of API traffic per sync — an
           # acceptable price for correctness.
 
           # Apply the full target MGMd manifest set rendered into the
-          # mounted ConfigMap. Server-side apply with field-manager=helm
-          # matches Helm's main apply field manager, so the subsequent
-          # main apply sees no diff and does not roll MGMd a second
-          # time. Applying the whole rendered manifest covers every
-          # field — nodeSelector, tolerations, resources, probes,
-          # sidecars, ConfigMap data — not just image and configIniHash.
-          #
-          # `--force-conflicts` is required because the existing
-          # mgmds/mgmd-configs/headless-mgmds resources may have been
-          # created by Helm 3 client-side apply (no SSA managedFields
-          # tracking), or by a different field-manager. SSA without
-          # force rejects the apply on conflict; with force the hook
-          # takes ownership of the fields it sets. Same content as the
-          # main apply will write, so this is the source-of-truth move
-          # rather than a hostile takeover.
-          log "Applying target MGMd manifests (server-side, field-manager=helm, force-conflicts)"
-          kubectl apply -n "$NAMESPACE" --server-side --field-manager=helm --force-conflicts \
+          # mounted ConfigMap. Client-side apply with field-manager=helm
+          # matches Helm 3's default apply mode, so the hook and the
+          # chart's main apply share the same write semantics; no SSA
+          # managedFields tracking, no field-ownership conflicts, no
+          # need for `--force-conflicts`. Applying the whole rendered
+          # manifest covers every field — nodeSelector, tolerations,
+          # resources, probes, sidecars, ConfigMap data — not just
+          # image and configIniHash.
+          log "Applying target MGMd manifests (client-side, field-manager=helm)"
+          kubectl apply -n "$NAMESPACE" --field-manager=helm \
               -f /etc/rondb-config/mgmd-manifests.yaml
 
           log "Waiting for $STS_NAME rollout to converge (timeout: $ROLLOUT_TIMEOUT)"

--- a/templates/mgmd_pre_upgrade.yaml
+++ b/templates/mgmd_pre_upgrade.yaml
@@ -159,10 +159,18 @@ spec:
           log "statefulset:            $STS_NAME"
           log "namespace:              $NAMESPACE"
 
-          # Fast-path: if the StatefulSet's pod template already matches the
-          # target image and configIniHash, there is no roll to wait for. We
-          # only verify MGMd is healthy and exit. This is the common case for
-          # upgrades that do not touch MGMd (e.g. scaling-only upgrades).
+          # The pod name for a single-replica StatefulSet is "<sts-name>-0";
+          # honour any override of meta.mgmd.statefulSetName.
+          POD_NAME="${STS_NAME}-0"
+          log "pod:                    $POD_NAME"
+
+          # Read the live pod template fields so we can decide whether a patch
+          # is needed. The patch itself is conditional (avoid touching the API
+          # when there's nothing to change), but the rollout-status wait below
+          # is unconditional — it must prove the StatefulSet has converged on
+          # the live spec before we let Helm proceed, even if a previous
+          # interrupted upgrade already wrote the target spec but did not
+          # finish rolling.
           live_image=$(kubectl get statefulset "$STS_NAME" -n "$NAMESPACE" \
               -o jsonpath='{.spec.template.spec.containers[?(@.name=="mgmd")].image}' \
               2>/dev/null || echo "")
@@ -196,17 +204,23 @@ spec:
                  }')
             kubectl patch statefulset "$STS_NAME" -n "$NAMESPACE" \
                 --type=strategic -p "$patch_json"
-
-            log "Waiting for $STS_NAME rollout (timeout: $ROLLOUT_TIMEOUT)"
-            kubectl rollout status statefulset/"$STS_NAME" -n "$NAMESPACE" \
-                --timeout="$ROLLOUT_TIMEOUT"
           else
-            log "MGMd already at target image and configIniHash; skipping patch + rollout"
+            log "Spec already at target image and configIniHash; no patch needed"
           fi
+
+          # Always wait for the rollout to converge. If the spec already
+          # matches the target and the controller is idle, this returns
+          # immediately. If a previous run patched the spec but was
+          # interrupted before the controller finished the rolling update,
+          # this is what catches it: we will not let Helm proceed while the
+          # MGMd StatefulSet is still mid-roll.
+          log "Waiting for $STS_NAME rollout to converge (timeout: $ROLLOUT_TIMEOUT)"
+          kubectl rollout status statefulset/"$STS_NAME" -n "$NAMESPACE" \
+              --timeout="$ROLLOUT_TIMEOUT"
 
           log "Verifying MGMd is serving (ndb_mgm -e show)"
           for attempt in $(seq 1 "$HEALTHCHECK_RETRIES"); do
-            if kubectl exec -n "$NAMESPACE" mgmds-0 -- ndb_mgm -e show >/dev/null 2>&1; then
+            if kubectl exec -n "$NAMESPACE" "$POD_NAME" -- ndb_mgm -e show >/dev/null 2>&1; then
               log "MGMd healthy after $attempt attempt(s); upgrade may proceed"
               exit 0
             fi

--- a/templates/mgmd_pre_upgrade.yaml
+++ b/templates/mgmd_pre_upgrade.yaml
@@ -1,0 +1,202 @@
+# Copyright (c) 2024-2026 Hopsworks AB. All rights reserved.
+
+{{- /*
+  Pre-upgrade ordering hook.
+
+  Helm and the StatefulSet controllers do not coordinate ordering between
+  the MGMd, ndbmtd, and API-tier (mysqld, rdrs, binlog-servers,
+  replica-appliers) StatefulSets. Their rolling updates run concurrently
+  during a chart upgrade, which means there can be a window where the MGMd
+  pod (the only ArbitrationRank=1 node), every mysqld, and every rdrs are
+  all unavailable at the same moment. If a data-node replica is also being
+  rolled in that window, the surviving data node has no arbitrator to
+  consult and self-shuts with NDB Error 2305.
+
+  This hook runs before the main upgrade applies any other manifest. It
+  brings the MGMd StatefulSet to its target pod template (new image, new
+  configIniHash, new config.ini in the mgmd-configs ConfigMap) and waits
+  for it to be Ready and serving (`ndb_mgm -e show`). When the main
+  upgrade then runs, the MGMd StatefulSet's running state already matches
+  the desired state, so MGMd is not rolled again — the rest of the
+  rollout proceeds with a stable, healthy primary arbitrator.
+*/}}
+
+{{- if and (include "rondb.isUpgrade" .) (not (include "rondb.isExternallyManaged" .)) }}
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: rondb-mgmd-pre-upgrade-config-{{ .Release.Revision }}
+  namespace: {{ .Release.Namespace }}
+  annotations:
+    "helm.sh/hook": pre-upgrade
+    "helm.sh/hook-weight": "-20"
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+data:
+  config.ini: |
+{{ tpl (.Files.Get "files/configs/config.ini") . | indent 4 }}
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: rondb-mgmd-pre-upgrade
+  namespace: {{ .Release.Namespace }}
+  annotations:
+    "helm.sh/hook": pre-upgrade
+    "helm.sh/hook-weight": "-20"
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: rondb-mgmd-pre-upgrade
+  namespace: {{ .Release.Namespace }}
+  annotations:
+    "helm.sh/hook": pre-upgrade
+    "helm.sh/hook-weight": "-20"
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+rules:
+- apiGroups: ["apps"]
+  resources: ["statefulsets"]
+  verbs: ["get", "patch", "watch"]
+  resourceNames: [{{ .Values.meta.mgmd.statefulSetName | quote }}]
+- apiGroups: ["apps"]
+  resources: ["statefulsets/status"]
+  verbs: ["get", "watch"]
+  resourceNames: [{{ .Values.meta.mgmd.statefulSetName | quote }}]
+- apiGroups: [""]
+  resources: ["configmaps"]
+  verbs: ["get", "patch"]
+  resourceNames: ["mgmd-configs"]
+- apiGroups: [""]
+  resources: ["pods"]
+  verbs: ["get", "list", "watch"]
+- apiGroups: [""]
+  resources: ["pods/exec"]
+  verbs: ["create"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: rondb-mgmd-pre-upgrade
+  namespace: {{ .Release.Namespace }}
+  annotations:
+    "helm.sh/hook": pre-upgrade
+    "helm.sh/hook-weight": "-20"
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+subjects:
+- kind: ServiceAccount
+  name: rondb-mgmd-pre-upgrade
+  namespace: {{ .Release.Namespace }}
+roleRef:
+  kind: Role
+  name: rondb-mgmd-pre-upgrade
+  apiGroup: rbac.authorization.k8s.io
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: rondb-mgmd-pre-upgrade-{{ .Release.Revision }}
+  namespace: {{ .Release.Namespace }}
+  annotations:
+    "helm.sh/hook": pre-upgrade
+    "helm.sh/hook-weight": "0"
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+spec:
+  backoffLimit: 3
+  template:
+    metadata:
+      labels:
+        rondbService: mgmd-pre-upgrade
+    spec:
+      serviceAccountName: rondb-mgmd-pre-upgrade
+      restartPolicy: Never
+{{- include "rondb.PodSecurityContext" $ | indent 6 }}
+{{- include "rondb.imagePullSecrets" . | indent 6 }}
+{{- include "rondb.nodeSelector" (dict "nodeSelector" .Values.nodeSelector.mgmd) | indent 6 }}
+{{- include "rondb.tolerations" (dict "tolerations" .Values.tolerations.mgmd) | indent 6 }}
+{{- if .Values.priorityClass }}
+      priorityClassName: {{ .Values.priorityClass | quote }}
+{{- end }}
+      containers:
+      - name: mgmd-pre-upgrade
+        image: {{ include "image_address" (dict "image" .Values.images.toolbox) }}
+        imagePullPolicy: {{ .Values.imagePullPolicy }}
+{{ include "rondb.ContainerSecurityContext" $ | indent 8 }}
+        resources:
+          limits:
+            cpu: 0.3
+            memory: 200Mi
+        env:
+        - name: STS_NAME
+          value: {{ .Values.meta.mgmd.statefulSetName | quote }}
+        - name: NAMESPACE
+          value: {{ .Release.Namespace | quote }}
+        - name: NEW_IMAGE
+          value: {{ include "image_address" (dict "image" .Values.images.rondb) | quote }}
+        - name: NEW_CONFIG_INI_HASH
+          value: {{ include "rondb.configIniHash" $ | quote }}
+        - name: ROLLOUT_TIMEOUT
+          value: "10m"
+        - name: HEALTHCHECK_RETRIES
+          value: "30"
+        - name: HEALTHCHECK_INTERVAL_SECONDS
+          value: "5"
+        volumeMounts:
+        - name: rendered-config
+          mountPath: /etc/rondb-config
+          readOnly: true
+        command:
+        - /bin/bash
+        - -c
+        - |
+          set -euo pipefail
+
+          echo "[mgmd-pre-upgrade] target image:        $NEW_IMAGE"
+          echo "[mgmd-pre-upgrade] target configIniHash: $NEW_CONFIG_INI_HASH"
+
+          echo "[mgmd-pre-upgrade] Updating mgmd-configs ConfigMap to new config.ini"
+          kubectl get configmap mgmd-configs -n "$NAMESPACE" -o json \
+            | jq --rawfile cfg /etc/rondb-config/config.ini '.data["config.ini"] = $cfg' \
+            | kubectl apply -n "$NAMESPACE" -f -
+
+          echo "[mgmd-pre-upgrade] Patching $STS_NAME pod template (image + configIniHash)"
+          kubectl patch statefulset "$STS_NAME" -n "$NAMESPACE" --type=strategic -p "$(cat <<EOF
+          {
+            "spec": {
+              "template": {
+                "metadata": {
+                  "annotations": {
+                    "configIniHash": "$NEW_CONFIG_INI_HASH"
+                  }
+                },
+                "spec": {
+                  "containers": [
+                    {"name": "mgmd", "image": "$NEW_IMAGE"}
+                  ]
+                }
+              }
+            }
+          }
+          EOF
+          )"
+
+          echo "[mgmd-pre-upgrade] Waiting for $STS_NAME rollout (timeout: $ROLLOUT_TIMEOUT)"
+          kubectl rollout status statefulset/"$STS_NAME" -n "$NAMESPACE" --timeout="$ROLLOUT_TIMEOUT"
+
+          echo "[mgmd-pre-upgrade] Verifying MGMd is serving (ndb_mgm -e show)"
+          for attempt in $(seq 1 "$HEALTHCHECK_RETRIES"); do
+            if kubectl exec -n "$NAMESPACE" mgmds-0 -- ndb_mgm -e show >/dev/null 2>&1; then
+              echo "[mgmd-pre-upgrade] MGMd healthy after $attempt attempt(s); upgrade may proceed"
+              exit 0
+            fi
+            echo "[mgmd-pre-upgrade] attempt $attempt/$HEALTHCHECK_RETRIES: MGMd not yet serving, sleeping ${HEALTHCHECK_INTERVAL_SECONDS}s"
+            sleep "$HEALTHCHECK_INTERVAL_SECONDS"
+          done
+          echo "[mgmd-pre-upgrade] MGMd did not become healthy within timeout" >&2
+          exit 1
+      volumes:
+      - name: rendered-config
+        configMap:
+          name: rondb-mgmd-pre-upgrade-config-{{ .Release.Revision }}
+{{- end }}

--- a/templates/mgmd_pre_upgrade.yaml
+++ b/templates/mgmd_pre_upgrade.yaml
@@ -215,41 +215,19 @@ spec:
             exit 0
           fi
 
-          # Read live pod-template fields and StatefulSet status. We use the
-          # combination to decide whether the StatefulSet is already
-          # converged at the target — that includes BOTH the spec being at
-          # target AND the controller having finished rolling. If both hold,
-          # there is nothing to do besides verifying health; we do not need
-          # to patch and we do not need to call `kubectl rollout status`,
-          # which was observed to block under CI even on idle StatefulSets.
-          read_sts() {
-            kubectl get statefulset "$STS_NAME" -n "$NAMESPACE" -o jsonpath="$1" 2>/dev/null || echo ""
-          }
-          live_image=$(read_sts '{.spec.template.spec.containers[?(@.name=="mgmd")].image}')
-          live_hash=$(read_sts  '{.spec.template.metadata.annotations.configIniHash}')
-          generation=$(read_sts '{.metadata.generation}')
-          observed=$(read_sts   '{.status.observedGeneration}')
-          spec_replicas=$(read_sts '{.spec.replicas}')
-          ready_replicas=$(read_sts   '{.status.readyReplicas}')
-          updated_replicas=$(read_sts '{.status.updatedReplicas}')
-          log "live image:             $live_image"
-          log "live configIniHash:     $live_hash"
-          log "generation:             $generation (observed: $observed)"
-          log "replicas spec/ready/updated: $spec_replicas/$ready_replicas/$updated_replicas"
-
-          spec_at_target=true
-          [ "$live_image" = "$NEW_IMAGE"           ] || spec_at_target=false
-          [ "$live_hash"  = "$NEW_CONFIG_INI_HASH" ] || spec_at_target=false
-
-          rollout_converged=true
-          [ -n "$generation" ] && [ -n "$observed" ] && [ "$generation" = "$observed" ] || rollout_converged=false
-          [ -n "$spec_replicas" ] && [ "$ready_replicas"   = "$spec_replicas" ] || rollout_converged=false
-          [ -n "$spec_replicas" ] && [ "$updated_replicas" = "$spec_replicas" ] || rollout_converged=false
-
-          if [ "$spec_at_target" = "true" ] && [ "$rollout_converged" = "true" ]; then
-            log "StatefulSet already at target image/hash and converged; nothing to do."
-            exit 0
-          fi
+          # No fast-path here: we used to short-circuit if the live
+          # image+hash matched the target, but the apply now writes the
+          # whole rendered template. A field outside of image/hash
+          # (nodeSelector, tolerations, resources, probes, sidecars …)
+          # changing would slip past such a check and let Helm's main
+          # apply roll MGMd a second time — exactly the silent-gap class
+          # of bug the full-apply rewrite exists to close. Instead we
+          # always apply: server-side apply against an already-correct
+          # live state is essentially a no-op (records co-ownership; no
+          # field change), and `kubectl rollout status` returns
+          # immediately on a converged StatefulSet. Steady-state Argo
+          # syncs incur ~1-2 seconds of API traffic per sync — an
+          # acceptable price for correctness.
 
           # Apply the full target MGMd manifest set rendered into the
           # mounted ConfigMap. Server-side apply with field-manager=helm

--- a/templates/mgmd_pre_upgrade.yaml
+++ b/templates/mgmd_pre_upgrade.yaml
@@ -189,63 +189,75 @@ spec:
             exit 0
           fi
 
-          # Read the live pod template fields so we can decide whether a patch
-          # is needed. The patch itself is conditional (avoid touching the API
-          # when there's nothing to change), but the rollout-status wait below
-          # is unconditional — it must prove the StatefulSet has converged on
-          # the live spec before we let Helm proceed, even if a previous
-          # interrupted upgrade already wrote the target spec but did not
-          # finish rolling.
-          live_image=$(kubectl get statefulset "$STS_NAME" -n "$NAMESPACE" \
-              -o jsonpath='{.spec.template.spec.containers[?(@.name=="mgmd")].image}' \
-              2>/dev/null || echo "")
-          live_hash=$(kubectl get statefulset "$STS_NAME" -n "$NAMESPACE" \
-              -o jsonpath='{.spec.template.metadata.annotations.configIniHash}' \
-              2>/dev/null || echo "")
+          # Read live pod-template fields and StatefulSet status. We use the
+          # combination to decide whether the StatefulSet is already
+          # converged at the target — that includes BOTH the spec being at
+          # target AND the controller having finished rolling. If both hold,
+          # there is nothing to do besides verifying health; we do not need
+          # to patch and we do not need to call `kubectl rollout status`,
+          # which was observed to block under CI even on idle StatefulSets.
+          read_sts() {
+            kubectl get statefulset "$STS_NAME" -n "$NAMESPACE" -o jsonpath="$1" 2>/dev/null || echo ""
+          }
+          live_image=$(read_sts '{.spec.template.spec.containers[?(@.name=="mgmd")].image}')
+          live_hash=$(read_sts  '{.spec.template.metadata.annotations.configIniHash}')
+          generation=$(read_sts '{.metadata.generation}')
+          observed=$(read_sts   '{.status.observedGeneration}')
+          spec_replicas=$(read_sts '{.spec.replicas}')
+          ready_replicas=$(read_sts   '{.status.readyReplicas}')
+          updated_replicas=$(read_sts '{.status.updatedReplicas}')
           log "live image:             $live_image"
           log "live configIniHash:     $live_hash"
+          log "generation:             $generation (observed: $observed)"
+          log "replicas spec/ready/updated: $spec_replicas/$ready_replicas/$updated_replicas"
 
-          needs_patch=0
-          [ "$live_image" = "$NEW_IMAGE" ] || needs_patch=1
-          [ "$live_hash"  = "$NEW_CONFIG_INI_HASH" ] || needs_patch=1
+          spec_at_target=true
+          [ "$live_image" = "$NEW_IMAGE"           ] || spec_at_target=false
+          [ "$live_hash"  = "$NEW_CONFIG_INI_HASH" ] || spec_at_target=false
 
-          if [ "$needs_patch" -eq 1 ]; then
-            log "Updating mgmd-configs ConfigMap to new config.ini"
-            kubectl get configmap mgmd-configs -n "$NAMESPACE" -o json \
-              | jq --rawfile cfg /etc/rondb-config/config.ini '.data["config.ini"] = $cfg' \
-              | kubectl apply -n "$NAMESPACE" -f -
+          rollout_converged=true
+          [ -n "$generation" ] && [ -n "$observed" ] && [ "$generation" = "$observed" ] || rollout_converged=false
+          [ -n "$spec_replicas" ] && [ "$ready_replicas"   = "$spec_replicas" ] || rollout_converged=false
+          [ -n "$spec_replicas" ] && [ "$updated_replicas" = "$spec_replicas" ] || rollout_converged=false
 
-            log "Patching $STS_NAME pod template (image + configIniHash)"
-            patch_json=$(jq -n \
-                --arg image "$NEW_IMAGE" \
-                --arg hash "$NEW_CONFIG_INI_HASH" \
-                '{
-                   spec: {
-                     template: {
-                       metadata: { annotations: { configIniHash: $hash } },
-                       spec: { containers: [ { name: "mgmd", image: $image } ] }
-                     }
-                   }
-                 }')
-            kubectl patch statefulset "$STS_NAME" -n "$NAMESPACE" \
-                --type=strategic -p "$patch_json"
+          if [ "$spec_at_target" = "true" ] && [ "$rollout_converged" = "true" ]; then
+            log "StatefulSet already converged at target; skipping patch and rollout-status"
           else
-            log "Spec already at target image and configIniHash; no patch needed"
-          fi
+            log "Patching: spec_at_target=$spec_at_target rollout_converged=$rollout_converged"
 
-          # Always wait for the rollout to converge. If the spec already
-          # matches the target and the controller is idle, this returns
-          # immediately. If a previous run patched the spec but was
-          # interrupted before the controller finished the rolling update,
-          # this is what catches it: we will not let Helm proceed while the
-          # MGMd StatefulSet is still mid-roll.
-          log "Waiting for $STS_NAME rollout to converge (timeout: $ROLLOUT_TIMEOUT)"
-          kubectl rollout status statefulset/"$STS_NAME" -n "$NAMESPACE" \
-              --timeout="$ROLLOUT_TIMEOUT"
+            if [ "$spec_at_target" = "false" ]; then
+              log "Updating mgmd-configs ConfigMap to new config.ini"
+              kubectl get configmap mgmd-configs -n "$NAMESPACE" -o json \
+                | jq --rawfile cfg /etc/rondb-config/config.ini '.data["config.ini"] = $cfg' \
+                | kubectl apply -n "$NAMESPACE" -f -
+
+              log "Patching $STS_NAME pod template (image + configIniHash)"
+              patch_json=$(jq -n \
+                  --arg image "$NEW_IMAGE" \
+                  --arg hash "$NEW_CONFIG_INI_HASH" \
+                  '{
+                     spec: {
+                       template: {
+                         metadata: { annotations: { configIniHash: $hash } },
+                         spec: { containers: [ { name: "mgmd", image: $image } ] }
+                       }
+                     }
+                   }')
+              kubectl patch statefulset "$STS_NAME" -n "$NAMESPACE" \
+                  --type=strategic -p "$patch_json"
+            fi
+
+            log "Waiting for $STS_NAME rollout to converge (timeout: $ROLLOUT_TIMEOUT)"
+            kubectl rollout status statefulset/"$STS_NAME" -n "$NAMESPACE" \
+                --timeout="$ROLLOUT_TIMEOUT"
+          fi
 
           log "Verifying MGMd is serving (ndb_mgm -e show)"
           for attempt in $(seq 1 "$HEALTHCHECK_RETRIES"); do
-            if kubectl exec -n "$NAMESPACE" "$POD_NAME" -- ndb_mgm -e show >/dev/null 2>&1; then
+            # Per-attempt request-timeout so a wedged kubectl exec can't
+            # hold the whole script open past helm's hook timeout budget.
+            if kubectl exec --request-timeout=5s -n "$NAMESPACE" "$POD_NAME" \
+                -- ndb_mgm -e show >/dev/null 2>&1; then
               log "MGMd healthy after $attempt attempt(s); upgrade may proceed"
               exit 0
             fi

--- a/templates/mgmd_pre_upgrade.yaml
+++ b/templates/mgmd_pre_upgrade.yaml
@@ -3,45 +3,34 @@
 {{- /*
   Pre-upgrade ordering hook.
 
-  Helm and the StatefulSet controllers do not coordinate ordering between
-  the MGMd, ndbmtd, and API-tier (mysqld, rdrs, binlog-servers,
-  replica-appliers) StatefulSets. Their rolling updates run concurrently
-  during a chart upgrade, which means there can be a window where the MGMd
-  pod (the only ArbitrationRank=1 node), every mysqld, and every rdrs are
-  all unavailable at the same moment. If a data-node replica is also being
-  rolled in that window, the surviving data node has no arbitrator to
-  consult and self-shuts with NDB Error 2305.
+  Helm doesn't sequence rolling updates across the MGMd, ndbmtd, and
+  API-tier (mysqld, rdrs, …) StatefulSets. Their rollouts overlap
+  during a chart upgrade, so the cluster can briefly have no live
+  MGMd (the only ArbitrationRank=1 node) while ndbmtds are also
+  cycling — the surviving ndbmtd then has no arbitrator and
+  self-shuts with NDB Error 2305.
 
-  This hook runs before the main upgrade applies any other manifest. It
-  applies the full target MGMd manifest set (StatefulSet, mgmd-configs
-  ConfigMap, headless Service — the same set the chart's main apply
-  would write) using client-side apply with field-manager=helm. When
-  the main upgrade then runs, it sees no diff against the hook-applied
-  state and does not roll MGMd a second time. The rest of the rollout
-  proceeds with a stable, healthy primary arbitrator.
-
-  The full-apply approach (vs. patching only image + configIniHash on
-  the StatefulSet) ensures every pod-template field — nodeSelector,
-  tolerations, resources, probes, sidecars, etc. — reaches MGMd before
-  the main apply runs, closing the silent-gap class of bug where a
-  chart-version bump that changes any of those fields would otherwise
-  trigger a second MGMd roll during the main apply.
+  This hook applies the full target MGMd manifest set (StatefulSet,
+  mgmd-configs ConfigMap, headless Service — the same set the chart's
+  main apply writes) before the main upgrade runs. The main apply
+  then sees no diff and doesn't roll MGMd again. Applying the whole
+  rendered manifest (not just image + configIniHash) covers every
+  pod-template field — nodeSelector, tolerations, resources, probes,
+  sidecars — so a chart-version bump touching any of them goes
+  through this hook rather than triggering a second MGMd roll later.
 
   Gating:
-  -------
-  The template renders on `helm upgrade` (`rondb.isUpgrade` true) and
-  is suppressed on `helm install` and on externally-managed clusters.
-  Argo CD deployments must set `mode=upgrade` (or `mode=install` on the
-  very first sync) so `rondb.isUpgrade` resolves correctly under Argo's
-  `helm template` render path, where `.Release.IsUpgrade` is always
-  false. An additional escape hatch is `Values.skipMgmdPreUpgradeRollout`
-  for cluster operators who need to disable the hook entirely without
-  changing chart versions.
+    Helm:    fires on `helm upgrade` (rondb.isUpgrade true);
+             suppressed on install and on externally-managed clusters.
+    Argo CD: customers must set `mode=upgrade` (or `mode=install` on
+             the first sync) since `.Release.IsUpgrade` is always
+             false under `helm template`.
+    Escape:  set `Values.skipMgmdPreUpgradeRollout=true` to disable
+             the hook without changing chart versions.
 
-  The Job script also handles the "MGMd does not exist yet" case
-  defensively (first Argo sync where `mode=upgrade` is set but the
-  StatefulSet has not been created yet) by exiting cleanly so Argo's
-  main sync can create MGMd from scratch.
+  The hook script exits cleanly when the MGMd StatefulSet doesn't
+  exist yet (Argo first-sync case), letting Argo's main sync create
+  MGMd from scratch.
 */}}
 
 {{- if and
@@ -52,11 +41,9 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  # Stable name (no Release.Revision suffix) so `before-hook-creation`
-  # actually matches and replaces the previous revision's ConfigMap.
-  # Argo CD's hook lifecycle treats non-Job hooks as "succeeded" the
-  # moment they're applied, so `hook-succeeded` here would let Argo
-  # delete this ConfigMap before the wave-10 Job mounts it.
+  # Stable name + before-hook-creation only. hook-succeeded would let
+  # Argo CD delete this ConfigMap before the wave-10 Job mounts it
+  # (Argo treats non-Job hooks as "succeeded" on apply).
   name: rondb-mgmd-pre-upgrade-config
   namespace: {{ .Release.Namespace }}
   annotations:
@@ -64,11 +51,9 @@ metadata:
     "helm.sh/hook-weight": "-20"
     "helm.sh/hook-delete-policy": before-hook-creation
 data:
-  # The full MGMd manifest set (StatefulSet + mgmd-configs ConfigMap +
-  # headless Service) rendered with this release's values. The hook Job
-  # mounts this file and applies it via client-side `kubectl apply`.
-  # Keep in sync via the `rondb.mgmdManifests` named template — the
-  # chart's main apply (templates/mgmd.yaml) renders the same definition.
+  # Full MGMd manifest set rendered with this release's values. Same
+  # definition as the chart's main apply (templates/mgmd.yaml) — both
+  # come from the `rondb.mgmdManifests` named template.
   mgmd-manifests.yaml: |
 {{ include "rondb.mgmdManifests" . | indent 4 }}
 ---
@@ -80,10 +65,8 @@ metadata:
   annotations:
     "helm.sh/hook": pre-upgrade
     "helm.sh/hook-weight": "-20"
-    # `hook-succeeded` would let Argo CD remove this support resource
-    # before the wave-10 Job that depends on it runs, so we keep
-    # `before-hook-creation` only. Stable names + before-hook-creation
-    # give us idempotent re-creation without the deletion race.
+    # before-hook-creation only; hook-succeeded would let Argo CD
+    # delete this support resource before the wave-10 Job runs.
     "helm.sh/hook-delete-policy": before-hook-creation
 ---
 apiVersion: rbac.authorization.k8s.io/v1
@@ -141,14 +124,12 @@ metadata:
   namespace: {{ .Release.Namespace }}
   annotations:
     "helm.sh/hook": pre-upgrade
-    # Hook-weight is set high enough that this hook runs after any other
-    # pre-upgrade hooks the chart defines (e.g. mysql privilege migration).
+    # Run after other pre-upgrade hooks (revoke-set-user-id-privilege
+    # has no explicit weight so it defaults to 0).
     "helm.sh/hook-weight": "10"
-    # `hook-succeeded` is required: the Job has `backoffLimit: 3`, so a
-    # transient first-attempt failure (e.g. `kubectl rollout status`
-    # exceeding ROLLOUT_TIMEOUT) is recovered by a retry pod, but the
-    # Failed pod from the first attempt would otherwise persist in the
-    # namespace and confuse downstream stability/cleanup checks.
+    # hook-succeeded cleans up backoff-retry pods after success; without
+    # it, a transient first-attempt failure leaves Failed pods that
+    # confuse downstream stability/cleanup checks.
     "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
 spec:
   backoffLimit: 3
@@ -197,53 +178,27 @@ spec:
           log "statefulset:    $STS_NAME"
           log "namespace:      $NAMESPACE"
 
-          # Fresh-install short-circuit. Under Helm, this template is only
-          # invoked as a `pre-upgrade` hook so it never runs on `helm
-          # install`. Under Argo CD, every sync (including the very first)
-          # fires PreSync hooks, so on a fresh install the StatefulSet does
-          # not exist yet and there is nothing to pre-roll. Exit cleanly
-          # and let Argo's main sync create MGMd from scratch.
+          # Fresh-install short-circuit for Argo CD's first sync, where
+          # PreSync hooks fire before the StatefulSet exists. Under Helm
+          # this hook only runs on upgrade so the case never arises.
           if ! kubectl get statefulset "$STS_NAME" -n "$NAMESPACE" >/dev/null 2>&1; then
-            log "StatefulSet $STS_NAME not found in namespace $NAMESPACE."
-            log "Treating this sync as an initial install; nothing to pre-roll. Exiting cleanly."
+            log "StatefulSet $STS_NAME not found; nothing to pre-roll, exiting."
             exit 0
           fi
 
-          # No fast-path here: we used to short-circuit if the live
-          # image+hash matched the target, but the apply now writes the
-          # whole rendered template. A field outside of image/hash
-          # (nodeSelector, tolerations, resources, probes, sidecars …)
-          # changing would slip past such a check and let Helm's main
-          # apply roll MGMd a second time — exactly the silent-gap class
-          # of bug the full-apply rewrite exists to close. Instead we
-          # always apply: client-side apply against an already-correct
-          # live state is essentially a no-op (kubectl computes the diff
-          # and finds none; no API write), and `kubectl rollout status`
-          # returns immediately on a converged StatefulSet. Steady-state
-          # Argo syncs incur ~1-2 seconds of API traffic per sync — an
-          # acceptable price for correctness.
-
-          # Apply the full target MGMd manifest set rendered into the
-          # mounted ConfigMap. Client-side apply with field-manager=helm
-          # matches Helm 3's default apply mode, so the hook and the
-          # chart's main apply share the same write semantics; no SSA
-          # managedFields tracking, no field-ownership conflicts, no
-          # need for `--force-conflicts`. Applying the whole rendered
-          # manifest covers every field — nodeSelector, tolerations,
-          # resources, probes, sidecars, ConfigMap data — not just
-          # image and configIniHash.
+          # No fast-path. A narrow image+hash check would miss other
+          # field changes (nodeSelector, tolerations, resources, probes,
+          # sidecars) that the full apply now covers. Always apply —
+          # client-side apply is a no-op when nothing differs, and
+          # rollout-status returns immediately if already converged.
           log "Applying target MGMd manifests (client-side, field-manager=helm)"
           kubectl apply -n "$NAMESPACE" --field-manager=helm \
               -f /etc/rondb-config/mgmd-manifests.yaml
 
+          # `kubectl rollout status` returns when the pod is Ready,
+          # which means its readiness probe (`ndb_mgm -e show`) is
+          # passing — that's the health proof too.
           log "Waiting for $STS_NAME rollout to converge (timeout: $ROLLOUT_TIMEOUT)"
-          # `kubectl rollout status` blocks until .status.readyReplicas ==
-          # .spec.replicas (among other invariants), and a Ready pod by
-          # definition has its readiness probe (`ndb_mgm -e show`) passing.
-          # That's the same property a separate `kubectl exec` healthcheck
-          # would verify, so there is no need for an additional healthcheck
-          # step after this — the rollout-status return is itself the
-          # health proof.
           if ! kubectl rollout status statefulset/"$STS_NAME" -n "$NAMESPACE" \
               --timeout="$ROLLOUT_TIMEOUT"; then
             log "rollout-status did not converge within $ROLLOUT_TIMEOUT"

--- a/templates/mgmd_pre_upgrade.yaml
+++ b/templates/mgmd_pre_upgrade.yaml
@@ -162,7 +162,7 @@ spec:
         - name: NAMESPACE
           value: {{ .Release.Namespace | quote }}
         - name: ROLLOUT_TIMEOUT
-          value: "3m"
+          value: {{ .Values.mgmdPreUpgradeRolloutTimeout | quote }}
         volumeMounts:
         - name: rendered-config
           mountPath: /etc/rondb-config

--- a/templates/mgmd_pre_upgrade.yaml
+++ b/templates/mgmd_pre_upgrade.yaml
@@ -20,21 +20,27 @@
   the desired state, so MGMd is not rolled again — the rest of the
   rollout proceeds with a stable, healthy primary arbitrator.
 
-  Why this template is not gated on `rondb.isUpgrade`:
-  -----------------------------------------------------
-  Argo CD does not run `helm install`/`helm upgrade`; it renders with
-  `helm template` and then syncs. `.Release.IsUpgrade` is therefore
-  always false under Argo, and any helper that bottoms out on it (like
-  `rondb.isUpgrade` when `mode` is unset) would prevent this hook from
-  ever rendering on Argo-managed clusters. To keep the hook compatible
-  with both pure-Helm and Argo CD deployments, the template renders
-  whenever the cluster is not externally-managed; the hook semantics
-  themselves (Helm `pre-upgrade` -> Argo `PreSync`) decide WHEN it runs,
-  and the Job script handles the "MGMd does not exist yet" case (first
-  Argo sync of a fresh install) by exiting cleanly.
+  Gating:
+  -------
+  The template renders on `helm upgrade` (`rondb.isUpgrade` true) and
+  is suppressed on `helm install` and on externally-managed clusters.
+  Argo CD deployments must set `mode=upgrade` (or `mode=install` on the
+  very first sync) so `rondb.isUpgrade` resolves correctly under Argo's
+  `helm template` render path, where `.Release.IsUpgrade` is always
+  false. An additional escape hatch is `Values.skipMgmdPreUpgradeRollout`
+  for cluster operators who need to disable the hook entirely without
+  changing chart versions.
+
+  The Job script also handles the "MGMd does not exist yet" case
+  defensively (first Argo sync where `mode=upgrade` is set but the
+  StatefulSet has not been created yet) by exiting cleanly so Argo's
+  main sync can create MGMd from scratch.
 */}}
 
-{{- if not (include "rondb.isExternallyManaged" .) }}
+{{- if and
+    (include "rondb.isUpgrade" .)
+    (not (include "rondb.isExternallyManaged" .))
+    (not .Values.skipMgmdPreUpgradeRollout) }}
 ---
 apiVersion: v1
 kind: ConfigMap
@@ -44,7 +50,6 @@ metadata:
   annotations:
     "helm.sh/hook": pre-upgrade
     "helm.sh/hook-weight": "-20"
-    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
 data:
   config.ini: |
 {{ tpl (.Files.Get "files/configs/config.ini") . | indent 4 }}
@@ -57,7 +62,6 @@ metadata:
   annotations:
     "helm.sh/hook": pre-upgrade
     "helm.sh/hook-weight": "-20"
-    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
@@ -67,7 +71,6 @@ metadata:
   annotations:
     "helm.sh/hook": pre-upgrade
     "helm.sh/hook-weight": "-20"
-    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
 rules:
 - apiGroups: ["apps"]
   resources: ["statefulsets"]
@@ -93,7 +96,6 @@ metadata:
   annotations:
     "helm.sh/hook": pre-upgrade
     "helm.sh/hook-weight": "-20"
-    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
 subjects:
 - kind: ServiceAccount
   name: rondb-mgmd-pre-upgrade
@@ -110,8 +112,9 @@ metadata:
   namespace: {{ .Release.Namespace }}
   annotations:
     "helm.sh/hook": pre-upgrade
-    "helm.sh/hook-weight": "0"
-    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+    # Hook-weight is set high enough that this hook runs after any other
+    # pre-upgrade hooks the chart defines (e.g. mysql privilege migration).
+    "helm.sh/hook-weight": "10"
 spec:
   backoffLimit: 3
   template:
@@ -219,9 +222,14 @@ spec:
 
           if [ "$spec_at_target" = "false" ]; then
             log "Updating mgmd-configs ConfigMap to new config.ini"
+            # `--field-manager=helm` keeps Helm's main upgrade as the
+            # owner of fields we touch. Under Helm 4 (server-side-apply by
+            # default) this prevents a manager-conflict between this Job
+            # and the subsequent helm-driven apply that would otherwise
+            # leave the resource jointly owned.
             kubectl get configmap mgmd-configs -n "$NAMESPACE" -o json \
               | jq --rawfile cfg /etc/rondb-config/config.ini '.data["config.ini"] = $cfg' \
-              | kubectl apply -n "$NAMESPACE" -f -
+              | kubectl apply -n "$NAMESPACE" --field-manager=helm -f -
 
             log "Patching $STS_NAME pod template (image + configIniHash)"
             patch_json=$(jq -n \
@@ -236,7 +244,7 @@ spec:
                    }
                  }')
             kubectl patch statefulset "$STS_NAME" -n "$NAMESPACE" \
-                --type=strategic -p "$patch_json"
+                --type=strategic --field-manager=helm -p "$patch_json"
           fi
 
           log "Waiting for $STS_NAME rollout to converge (timeout: $ROLLOUT_TIMEOUT)"

--- a/templates/mgmd_pre_upgrade.yaml
+++ b/templates/mgmd_pre_upgrade.yaml
@@ -84,9 +84,6 @@ rules:
 - apiGroups: [""]
   resources: ["pods"]
   verbs: ["get", "list", "watch"]
-- apiGroups: [""]
-  resources: ["pods/exec"]
-  verbs: ["create"]
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
@@ -151,10 +148,6 @@ spec:
           value: {{ include "rondb.configIniHash" $ | quote }}
         - name: ROLLOUT_TIMEOUT
           value: "3m"
-        - name: HEALTHCHECK_RETRIES
-          value: "30"
-        - name: HEALTHCHECK_INTERVAL_SECONDS
-          value: "2"
         volumeMounts:
         - name: rendered-config
           mountPath: /etc/rondb-config
@@ -171,11 +164,6 @@ spec:
           log "target configIniHash:   $NEW_CONFIG_INI_HASH"
           log "statefulset:            $STS_NAME"
           log "namespace:              $NAMESPACE"
-
-          # The pod name for a single-replica StatefulSet is "<sts-name>-0";
-          # honour any override of meta.mgmd.statefulSetName.
-          POD_NAME="${STS_NAME}-0"
-          log "pod:                    $POD_NAME"
 
           # Fresh-install short-circuit. Under Helm, this template is only
           # invoked as a `pre-upgrade` hook so it never runs on `helm
@@ -221,55 +209,55 @@ spec:
           [ -n "$spec_replicas" ] && [ "$updated_replicas" = "$spec_replicas" ] || rollout_converged=false
 
           if [ "$spec_at_target" = "true" ] && [ "$rollout_converged" = "true" ]; then
-            log "StatefulSet already converged at target; skipping patch and rollout-status"
-          else
-            log "Patching: spec_at_target=$spec_at_target rollout_converged=$rollout_converged"
-
-            if [ "$spec_at_target" = "false" ]; then
-              log "Updating mgmd-configs ConfigMap to new config.ini"
-              kubectl get configmap mgmd-configs -n "$NAMESPACE" -o json \
-                | jq --rawfile cfg /etc/rondb-config/config.ini '.data["config.ini"] = $cfg' \
-                | kubectl apply -n "$NAMESPACE" -f -
-
-              log "Patching $STS_NAME pod template (image + configIniHash)"
-              patch_json=$(jq -n \
-                  --arg image "$NEW_IMAGE" \
-                  --arg hash "$NEW_CONFIG_INI_HASH" \
-                  '{
-                     spec: {
-                       template: {
-                         metadata: { annotations: { configIniHash: $hash } },
-                         spec: { containers: [ { name: "mgmd", image: $image } ] }
-                       }
-                     }
-                   }')
-              kubectl patch statefulset "$STS_NAME" -n "$NAMESPACE" \
-                  --type=strategic -p "$patch_json"
-            fi
-
-            log "Waiting for $STS_NAME rollout to converge (timeout: $ROLLOUT_TIMEOUT)"
-            kubectl rollout status statefulset/"$STS_NAME" -n "$NAMESPACE" \
-                --timeout="$ROLLOUT_TIMEOUT"
+            log "StatefulSet already converged at target; nothing to do."
+            log "(.status.readyReplicas == .spec.replicas means the StatefulSet's"
+            log "own readiness probe — 'ndb_mgm -e show' — is already passing.)"
+            exit 0
           fi
 
-          log "Verifying MGMd is serving (ndb_mgm -e show)"
-          for attempt in $(seq 1 "$HEALTHCHECK_RETRIES"); do
-            # Per-attempt request-timeout so a wedged kubectl exec can't
-            # hold the whole script open past helm's hook timeout budget.
-            if kubectl exec --request-timeout=5s -n "$NAMESPACE" "$POD_NAME" \
-                -- ndb_mgm -e show >/dev/null 2>&1; then
-              log "MGMd healthy after $attempt attempt(s); upgrade may proceed"
-              exit 0
-            fi
-            log "attempt $attempt/$HEALTHCHECK_RETRIES: MGMd not yet serving, sleeping ${HEALTHCHECK_INTERVAL_SECONDS}s"
-            sleep "$HEALTHCHECK_INTERVAL_SECONDS"
-          done
+          log "Patching: spec_at_target=$spec_at_target rollout_converged=$rollout_converged"
 
-          log "MGMd did not become healthy within timeout"
-          log "--- final diagnostics ---"
-          kubectl get pods -n "$NAMESPACE" -l rondbService=mgmd -o wide || true
-          kubectl describe statefulset "$STS_NAME" -n "$NAMESPACE" || true
-          exit 1
+          if [ "$spec_at_target" = "false" ]; then
+            log "Updating mgmd-configs ConfigMap to new config.ini"
+            kubectl get configmap mgmd-configs -n "$NAMESPACE" -o json \
+              | jq --rawfile cfg /etc/rondb-config/config.ini '.data["config.ini"] = $cfg' \
+              | kubectl apply -n "$NAMESPACE" -f -
+
+            log "Patching $STS_NAME pod template (image + configIniHash)"
+            patch_json=$(jq -n \
+                --arg image "$NEW_IMAGE" \
+                --arg hash "$NEW_CONFIG_INI_HASH" \
+                '{
+                   spec: {
+                     template: {
+                       metadata: { annotations: { configIniHash: $hash } },
+                       spec: { containers: [ { name: "mgmd", image: $image } ] }
+                     }
+                   }
+                 }')
+            kubectl patch statefulset "$STS_NAME" -n "$NAMESPACE" \
+                --type=strategic -p "$patch_json"
+          fi
+
+          log "Waiting for $STS_NAME rollout to converge (timeout: $ROLLOUT_TIMEOUT)"
+          # `kubectl rollout status` blocks until .status.readyReplicas ==
+          # .spec.replicas (among other invariants), and a Ready pod by
+          # definition has its readiness probe (`ndb_mgm -e show`) passing.
+          # That's the same property a separate `kubectl exec` healthcheck
+          # would verify, so there is no need for an additional healthcheck
+          # step after this — the rollout-status return is itself the
+          # health proof.
+          if ! kubectl rollout status statefulset/"$STS_NAME" -n "$NAMESPACE" \
+              --timeout="$ROLLOUT_TIMEOUT"; then
+            log "rollout-status did not converge within $ROLLOUT_TIMEOUT"
+            log "--- final diagnostics ---"
+            kubectl get pods -n "$NAMESPACE" -l rondbService=mgmd -o wide || true
+            kubectl describe statefulset "$STS_NAME" -n "$NAMESPACE" || true
+            exit 1
+          fi
+
+          log "MGMd is serving the new pod template; upgrade may proceed"
+          exit 0
       volumes:
       - name: rendered-config
         configMap:

--- a/templates/mgmd_pre_upgrade.yaml
+++ b/templates/mgmd_pre_upgrade.yaml
@@ -13,12 +13,19 @@
   consult and self-shuts with NDB Error 2305.
 
   This hook runs before the main upgrade applies any other manifest. It
-  brings the MGMd StatefulSet to its target pod template (new image, new
-  configIniHash, new config.ini in the mgmd-configs ConfigMap) and waits
-  for it to be Ready and serving (`ndb_mgm -e show`). When the main
-  upgrade then runs, the MGMd StatefulSet's running state already matches
-  the desired state, so MGMd is not rolled again — the rest of the
-  rollout proceeds with a stable, healthy primary arbitrator.
+  applies the full target MGMd manifest set (StatefulSet, mgmd-configs
+  ConfigMap, headless Service — the same set the chart's main apply
+  would write) using server-side apply with field-manager=helm. When
+  the main upgrade then runs, it sees no diff against the hook-applied
+  state and does not roll MGMd a second time. The rest of the rollout
+  proceeds with a stable, healthy primary arbitrator.
+
+  The full-apply approach (vs. patching only image + configIniHash on
+  the StatefulSet) ensures every pod-template field — nodeSelector,
+  tolerations, resources, probes, sidecars, etc. — reaches MGMd before
+  the main apply runs, closing the silent-gap class of bug where a
+  chart-version bump that changes any of those fields would otherwise
+  trigger a second MGMd roll during the main apply.
 
   Gating:
   -------
@@ -57,8 +64,13 @@ metadata:
     "helm.sh/hook-weight": "-20"
     "helm.sh/hook-delete-policy": before-hook-creation
 data:
-  config.ini: |
-{{ tpl (.Files.Get "files/configs/config.ini") . | indent 4 }}
+  # The full MGMd manifest set (StatefulSet + mgmd-configs ConfigMap +
+  # headless Service) rendered with this release's values. The hook Job
+  # mounts this file and applies it server-side. Keep in sync via the
+  # `rondb.mgmdManifests` named template — the chart's main apply
+  # (templates/mgmd.yaml) renders the same definition.
+  mgmd-manifests.yaml: |
+{{ include "rondb.mgmdManifests" . | indent 4 }}
 ---
 apiVersion: v1
 kind: ServiceAccount
@@ -96,6 +108,10 @@ rules:
   resources: ["configmaps"]
   verbs: ["get", "patch"]
   resourceNames: ["mgmd-configs"]
+- apiGroups: [""]
+  resources: ["services"]
+  verbs: ["get", "patch"]
+  resourceNames: [{{ .Values.meta.mgmd.headlessClusterIp.name | quote }}]
 - apiGroups: [""]
   resources: ["pods"]
   verbs: ["get", "list", "watch"]
@@ -231,40 +247,20 @@ spec:
           [ -n "$spec_replicas" ] && [ "$updated_replicas" = "$spec_replicas" ] || rollout_converged=false
 
           if [ "$spec_at_target" = "true" ] && [ "$rollout_converged" = "true" ]; then
-            log "StatefulSet already converged at target; nothing to do."
-            log "(.status.readyReplicas == .spec.replicas means the StatefulSet's"
-            log "own readiness probe — 'ndb_mgm -e show' — is already passing.)"
+            log "StatefulSet already at target image/hash and converged; nothing to do."
             exit 0
           fi
 
-          log "Patching: spec_at_target=$spec_at_target rollout_converged=$rollout_converged"
-
-          if [ "$spec_at_target" = "false" ]; then
-            log "Updating mgmd-configs ConfigMap to new config.ini"
-            # `--field-manager=helm` keeps Helm's main upgrade as the
-            # owner of fields we touch. Under Helm 4 (server-side-apply by
-            # default) this prevents a manager-conflict between this Job
-            # and the subsequent helm-driven apply that would otherwise
-            # leave the resource jointly owned.
-            kubectl get configmap mgmd-configs -n "$NAMESPACE" -o json \
-              | jq --rawfile cfg /etc/rondb-config/config.ini '.data["config.ini"] = $cfg' \
-              | kubectl apply -n "$NAMESPACE" --field-manager=helm -f -
-
-            log "Patching $STS_NAME pod template (image + configIniHash)"
-            patch_json=$(jq -n \
-                --arg image "$NEW_IMAGE" \
-                --arg hash "$NEW_CONFIG_INI_HASH" \
-                '{
-                   spec: {
-                     template: {
-                       metadata: { annotations: { configIniHash: $hash } },
-                       spec: { containers: [ { name: "mgmd", image: $image } ] }
-                     }
-                   }
-                 }')
-            kubectl patch statefulset "$STS_NAME" -n "$NAMESPACE" \
-                --type=strategic --field-manager=helm -p "$patch_json"
-          fi
+          # Apply the full target MGMd manifest set rendered into the
+          # mounted ConfigMap. Server-side apply with field-manager=helm
+          # matches Helm's main apply field manager, so the subsequent
+          # main apply sees no diff and does not roll MGMd a second
+          # time. Applying the whole rendered manifest covers every
+          # field — nodeSelector, tolerations, resources, probes,
+          # sidecars, ConfigMap data — not just image and configIniHash.
+          log "Applying target MGMd manifests (server-side, field-manager=helm)"
+          kubectl apply -n "$NAMESPACE" --server-side --field-manager=helm \
+              -f /etc/rondb-config/mgmd-manifests.yaml
 
           log "Waiting for $STS_NAME rollout to converge (timeout: $ROLLOUT_TIMEOUT)"
           # `kubectl rollout status` blocks until .status.readyReplicas ==

--- a/templates/mgmd_pre_upgrade.yaml
+++ b/templates/mgmd_pre_upgrade.yaml
@@ -180,10 +180,6 @@ spec:
           value: {{ .Values.meta.mgmd.statefulSetName | quote }}
         - name: NAMESPACE
           value: {{ .Release.Namespace | quote }}
-        - name: NEW_IMAGE
-          value: {{ include "image_address" (dict "image" .Values.images.rondb) | quote }}
-        - name: NEW_CONFIG_INI_HASH
-          value: {{ include "rondb.configIniHash" $ | quote }}
         - name: ROLLOUT_TIMEOUT
           value: "3m"
         volumeMounts:
@@ -198,10 +194,8 @@ spec:
 
           log() { echo "[mgmd-pre-upgrade] $*"; }
 
-          log "target image:           $NEW_IMAGE"
-          log "target configIniHash:   $NEW_CONFIG_INI_HASH"
-          log "statefulset:            $STS_NAME"
-          log "namespace:              $NAMESPACE"
+          log "statefulset:    $STS_NAME"
+          log "namespace:      $NAMESPACE"
 
           # Fresh-install short-circuit. Under Helm, this template is only
           # invoked as a `pre-upgrade` hook so it never runs on `helm

--- a/templates/mgmd_pre_upgrade.yaml
+++ b/templates/mgmd_pre_upgrade.yaml
@@ -19,9 +19,22 @@
   upgrade then runs, the MGMd StatefulSet's running state already matches
   the desired state, so MGMd is not rolled again — the rest of the
   rollout proceeds with a stable, healthy primary arbitrator.
+
+  Why this template is not gated on `rondb.isUpgrade`:
+  -----------------------------------------------------
+  Argo CD does not run `helm install`/`helm upgrade`; it renders with
+  `helm template` and then syncs. `.Release.IsUpgrade` is therefore
+  always false under Argo, and any helper that bottoms out on it (like
+  `rondb.isUpgrade` when `mode` is unset) would prevent this hook from
+  ever rendering on Argo-managed clusters. To keep the hook compatible
+  with both pure-Helm and Argo CD deployments, the template renders
+  whenever the cluster is not externally-managed; the hook semantics
+  themselves (Helm `pre-upgrade` -> Argo `PreSync`) decide WHEN it runs,
+  and the Job script handles the "MGMd does not exist yet" case (first
+  Argo sync of a fresh install) by exiting cleanly.
 */}}
 
-{{- if and (include "rondb.isUpgrade" .) (not (include "rondb.isExternallyManaged" .)) }}
+{{- if not (include "rondb.isExternallyManaged" .) }}
 ---
 apiVersion: v1
 kind: ConfigMap
@@ -163,6 +176,18 @@ spec:
           # honour any override of meta.mgmd.statefulSetName.
           POD_NAME="${STS_NAME}-0"
           log "pod:                    $POD_NAME"
+
+          # Fresh-install short-circuit. Under Helm, this template is only
+          # invoked as a `pre-upgrade` hook so it never runs on `helm
+          # install`. Under Argo CD, every sync (including the very first)
+          # fires PreSync hooks, so on a fresh install the StatefulSet does
+          # not exist yet and there is nothing to pre-roll. Exit cleanly
+          # and let Argo's main sync create MGMd from scratch.
+          if ! kubectl get statefulset "$STS_NAME" -n "$NAMESPACE" >/dev/null 2>&1; then
+            log "StatefulSet $STS_NAME not found in namespace $NAMESPACE."
+            log "Treating this sync as an initial install; nothing to pre-roll. Exiting cleanly."
+            exit 0
+          fi
 
           # Read the live pod template fields so we can decide whether a patch
           # is needed. The patch itself is conditional (avoid touching the API

--- a/templates/mysqlds/revoke_set_user_id_privilege.yaml
+++ b/templates/mysqlds/revoke_set_user_id_privilege.yaml
@@ -7,6 +7,20 @@
   For this we read the Image from the mgmd Pod and extract the version.
   The admin privileges will be restored in the new 24.x cluster by the 2410_update_grant_all.yaml Job
   For more information: HWORKS-2315 CLOUD-857
+
+  Argo CD compatibility:
+  - The template is no longer gated on `rondb.isUpgrade`, which falls back to
+    `.Release.IsUpgrade` and is always false under Argo CD (Argo renders with
+    `helm template`, not `helm install`/`helm upgrade`). The Helm `pre-upgrade`
+    annotation alone keeps Helm from running the Job on a fresh `helm install`.
+  - Under Argo CD, the `lookup` call above returns nil (Argo's render path has
+    no cluster access by default), so `$execute` falls back to
+    `.Values.mysql.force2410UserGrantMigration`. Argo customers who need this
+    migration must set that value to true explicitly; otherwise the Job is
+    not rendered.
+  - `helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded` is set
+    so Argo (which applies hooks via kubectl apply) replaces the Job on each
+    sync rather than skipping a same-named Job that already exists.
 */}}
 {{- $execute := true }}
 {{- $sts := lookup "apps/v1" "StatefulSet" .Release.Namespace .Values.meta.mgmd.statefulSetName }}
@@ -26,7 +40,7 @@
 {{- else }}
   {{- $execute = .Values.mysql.force2410UserGrantMigration }}
 {{- end }}
-{{- if and $execute (include "rondb.isUpgrade" .) }}
+{{- if $execute }}
 apiVersion: batch/v1
 kind: Job
 metadata:
@@ -34,6 +48,7 @@ metadata:
   namespace: {{ .Release.Namespace }}
   annotations:
     "helm.sh/hook": pre-upgrade
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
 spec:
   backoffLimit: 5
   parallelism: 1

--- a/templates/mysqlds/revoke_set_user_id_privilege.yaml
+++ b/templates/mysqlds/revoke_set_user_id_privilege.yaml
@@ -40,6 +40,12 @@ metadata:
   namespace: {{ .Release.Namespace }}
   annotations:
     "helm.sh/hook": pre-upgrade
+    # Explicit `before-hook-creation` aligns with Argo CD's documented
+    # recommendation for named pre-upgrade hooks: ensures the previous
+    # run's Job is replaced on every sync/retry rather than left to
+    # collide. Helm 3 defaults to this policy implicitly; making it
+    # explicit keeps Argo CD behaviour predictable.
+    "helm.sh/hook-delete-policy": before-hook-creation
 spec:
   backoffLimit: 5
   parallelism: 1

--- a/templates/mysqlds/revoke_set_user_id_privilege.yaml
+++ b/templates/mysqlds/revoke_set_user_id_privilege.yaml
@@ -8,19 +8,11 @@
   The admin privileges will be restored in the new 24.x cluster by the 2410_update_grant_all.yaml Job
   For more information: HWORKS-2315 CLOUD-857
 
-  Argo CD compatibility:
-  - The template is no longer gated on `rondb.isUpgrade`, which falls back to
-    `.Release.IsUpgrade` and is always false under Argo CD (Argo renders with
-    `helm template`, not `helm install`/`helm upgrade`). The Helm `pre-upgrade`
-    annotation alone keeps Helm from running the Job on a fresh `helm install`.
-  - Under Argo CD, the `lookup` call above returns nil (Argo's render path has
-    no cluster access by default), so `$execute` falls back to
-    `.Values.mysql.force2410UserGrantMigration`. Argo customers who need this
-    migration must set that value to true explicitly; otherwise the Job is
-    not rendered.
-  - `helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded` is set
-    so Argo (which applies hooks via kubectl apply) replaces the Job on each
-    sync rather than skipping a same-named Job that already exists.
+  Argo CD note: under Argo, `lookup` returns nil (Argo renders with
+  `helm template`, which has no cluster access by default), so `$execute`
+  falls back to `.Values.mysql.force2410UserGrantMigration`. Argo customers
+  upgrading from a pre-24.x cluster must set that value to true explicitly,
+  and must set `mode=upgrade` so `rondb.isUpgrade` resolves true.
 */}}
 {{- $execute := true }}
 {{- $sts := lookup "apps/v1" "StatefulSet" .Release.Namespace .Values.meta.mgmd.statefulSetName }}
@@ -40,7 +32,7 @@
 {{- else }}
   {{- $execute = .Values.mysql.force2410UserGrantMigration }}
 {{- end }}
-{{- if $execute }}
+{{- if and $execute (include "rondb.isUpgrade" .) }}
 apiVersion: batch/v1
 kind: Job
 metadata:
@@ -48,7 +40,6 @@ metadata:
   namespace: {{ .Release.Namespace }}
   annotations:
     "helm.sh/hook": pre-upgrade
-    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
 spec:
   backoffLimit: 5
   parallelism: 1

--- a/templates/ndbd.yaml
+++ b/templates/ndbd.yaml
@@ -15,28 +15,6 @@ spec:
   # cluster (using flag --initial), the MGMd will wait for all
   # data nodes to start at the same time.
   podManagementPolicy: Parallel
-  # `podManagementPolicy: Parallel` removes the StatefulSet
-  # controller's "wait for previous pod Ready before terminating
-  # the next" gate that `OrderedReady` enforces. Without an
-  # explicit `maxUnavailable`, that means a chart upgrade can
-  # terminate every ndbmtd replica in a node group simultaneously,
-  # leaving the cluster with no live data nodes. When the new pods
-  # come up they each see no peer alive and enter system-restart
-  # mode (`Start phase 0 completed (system restart)` in cluster.log)
-  # — a brief cluster-wide outage that should never happen on a
-  # rolling upgrade.
-  #
-  # `updateStrategy.rollingUpdate.maxUnavailable: 1` re-introduces
-  # the serial gate for *updates* without changing the parallel
-  # behaviour for fresh-install pod *creation* (which is what
-  # `Parallel` is here for in the first place). Note: this field
-  # is honoured natively from Kubernetes 1.27+ (beta) and 1.31+
-  # (GA); on older clusters it is silently ignored and rolling
-  # updates remain parallel until the cluster is upgraded.
-  updateStrategy:
-    type: RollingUpdate
-    rollingUpdate:
-      maxUnavailable: 1
   replicas: {{ $.Values.clusterSize.activeDataReplicas }}
   selector:
     # Used by the Deployment to select and manage existing pods with the specified label

--- a/templates/ndbd.yaml
+++ b/templates/ndbd.yaml
@@ -15,6 +15,28 @@ spec:
   # cluster (using flag --initial), the MGMd will wait for all
   # data nodes to start at the same time.
   podManagementPolicy: Parallel
+  # `podManagementPolicy: Parallel` removes the StatefulSet
+  # controller's "wait for previous pod Ready before terminating
+  # the next" gate that `OrderedReady` enforces. Without an
+  # explicit `maxUnavailable`, that means a chart upgrade can
+  # terminate every ndbmtd replica in a node group simultaneously,
+  # leaving the cluster with no live data nodes. When the new pods
+  # come up they each see no peer alive and enter system-restart
+  # mode (`Start phase 0 completed (system restart)` in cluster.log)
+  # — a brief cluster-wide outage that should never happen on a
+  # rolling upgrade.
+  #
+  # `updateStrategy.rollingUpdate.maxUnavailable: 1` re-introduces
+  # the serial gate for *updates* without changing the parallel
+  # behaviour for fresh-install pod *creation* (which is what
+  # `Parallel` is here for in the first place). Note: this field
+  # is honoured natively from Kubernetes 1.27+ (beta) and 1.31+
+  # (GA); on older clusters it is silently ignored and rolling
+  # updates remain parallel until the cluster is upgraded.
+  updateStrategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: 1
   replicas: {{ $.Values.clusterSize.activeDataReplicas }}
   selector:
     # Used by the Deployment to select and manage existing pods with the specified label

--- a/values.schema.json
+++ b/values.schema.json
@@ -12,6 +12,11 @@
             ],
             "default": ""
         },
+        "mgmdPreUpgradeRolloutTimeout": {
+            "type": "string",
+            "description": "Timeout for `kubectl rollout status` inside the MGMd pre-upgrade hook (per attempt). Increase on slow networks or when image pull is expected to take longer. Note: Helm's `helm upgrade --timeout` (default 5m) bounds the total upgrade including this hook, so customers who want this timeout to be effective should set helm's timeout high enough to accommodate it.",
+            "default": "5m"
+        },
         "skipMgmdPreUpgradeRollout": {
             "type": "boolean",
             "description": "If true, skip the pre-upgrade hook that rolls MGMd to the target image and config before the rest of the chart upgrades. The hook exists to keep at least one ArbitrationRank=1 node reachable while the API tier (mysqld, rdrs) is also rolling, preventing data-node arbitration loss (NDB Error 2305) on chart-wide upgrades. Set this to true only as an escape hatch if the hook itself is misbehaving on your cluster.",

--- a/values.schema.json
+++ b/values.schema.json
@@ -14,8 +14,8 @@
         },
         "mgmdPreUpgradeRolloutTimeout": {
             "type": "string",
-            "description": "Timeout for `kubectl rollout status` inside the MGMd pre-upgrade hook (per attempt). Increase on slow networks or when image pull is expected to take longer. Note: Helm's `helm upgrade --timeout` (default 5m) bounds the total upgrade including this hook, so customers who want this timeout to be effective should set helm's timeout high enough to accommodate it.",
-            "default": "5m"
+            "description": "Timeout for `kubectl rollout status` inside the MGMd pre-upgrade hook (per attempt). Default 3m, deliberately below Helm's default `helm upgrade --timeout` of 5m so the hook fails with a clear, hook-specific error before Helm's generic outer timeout fires. Increase only if you also raise Helm's `--timeout` (e.g. on slow networks or large image pulls); a larger value at default Helm timeout will race with Helm and produce a generic 'timed out waiting for the condition' error instead of the hook's diagnostic.",
+            "default": "3m"
         },
         "skipMgmdPreUpgradeRollout": {
             "type": "boolean",

--- a/values.schema.json
+++ b/values.schema.json
@@ -14,8 +14,8 @@
         },
         "mgmdPreUpgradeRolloutTimeout": {
             "type": "string",
-            "description": "Timeout for `kubectl rollout status` inside the MGMd pre-upgrade hook (per attempt). Default 3m, deliberately below Helm's default `helm upgrade --timeout` of 5m so the hook fails with a clear, hook-specific error before Helm's generic outer timeout fires. Increase only if you also raise Helm's `--timeout` (e.g. on slow networks or large image pulls); a larger value at default Helm timeout will race with Helm and produce a generic 'timed out waiting for the condition' error instead of the hook's diagnostic.",
-            "default": "3m"
+            "description": "Timeout for `kubectl rollout status` inside the MGMd pre-upgrade hook (per attempt). Default 5m. Note: Helm's default `helm upgrade --timeout` is also 5m and bounds the whole upgrade including this hook — operators running with that default may see Helm's outer timeout fire first with a generic 'timed out waiting for the condition' message instead of this hook's specific diagnostic. Set Helm's `--timeout` higher (e.g. 15m) on slow networks or large image pulls.",
+            "default": "5m"
         },
         "skipMgmdPreUpgradeRollout": {
             "type": "boolean",

--- a/values.schema.json
+++ b/values.schema.json
@@ -12,6 +12,11 @@
             ],
             "default": ""
         },
+        "skipMgmdPreUpgradeRollout": {
+            "type": "boolean",
+            "description": "If true, skip the pre-upgrade hook that rolls MGMd to the target image and config before the rest of the chart upgrades. The hook exists to keep at least one ArbitrationRank=1 node reachable while the API tier (mysqld, rdrs) is also rolling, preventing data-node arbitration loss (NDB Error 2305) on chart-wide upgrades. Set this to true only as an escape hatch if the hook itself is misbehaving on your cluster.",
+            "default": false
+        },
         "imagePullPolicy": {
             "type": "string",
             "description": "The Kubernetes image pull policy",

--- a/values.yaml
+++ b/values.yaml
@@ -375,7 +375,7 @@ rondbConfig:
   TransactionMemory: null
   UseOnlyIPv4: null
 serviceAccountAnnotations: {}
-mgmdPreUpgradeRolloutTimeout: "5m"
+mgmdPreUpgradeRolloutTimeout: "3m"
 skipMgmdPreUpgradeRollout: false
 staticCpuManagerPolicy: false
 terminationGracePeriodSeconds: 60

--- a/values.yaml
+++ b/values.yaml
@@ -375,6 +375,7 @@ rondbConfig:
   TransactionMemory: null
   UseOnlyIPv4: null
 serviceAccountAnnotations: {}
+skipMgmdPreUpgradeRollout: false
 staticCpuManagerPolicy: false
 terminationGracePeriodSeconds: 60
 timeoutsMinutes:

--- a/values.yaml
+++ b/values.yaml
@@ -375,7 +375,7 @@ rondbConfig:
   TransactionMemory: null
   UseOnlyIPv4: null
 serviceAccountAnnotations: {}
-mgmdPreUpgradeRolloutTimeout: "3m"
+mgmdPreUpgradeRolloutTimeout: "5m"
 skipMgmdPreUpgradeRollout: false
 staticCpuManagerPolicy: false
 terminationGracePeriodSeconds: 60

--- a/values.yaml
+++ b/values.yaml
@@ -375,6 +375,7 @@ rondbConfig:
   TransactionMemory: null
   UseOnlyIPv4: null
 serviceAccountAnnotations: {}
+mgmdPreUpgradeRolloutTimeout: "5m"
 skipMgmdPreUpgradeRollout: false
 staticCpuManagerPolicy: false
 terminationGracePeriodSeconds: 60


### PR DESCRIPTION
Helm and the StatefulSet controllers do not coordinate ordering between the MGMd, ndbmtd, and API-tier (mysqld, rdrs, binlog-servers, replica-appliers) StatefulSets, so their rolling updates run concurrently during a chart upgrade. When the rollout windows of MGMd, all mysqlds, and all rdrs happen to overlap, the cluster has zero connected ArbitrationRank>0 nodes for several seconds. If a data-node replica is also being rolled in that window, the surviving replica self-shuts with NDB Error 2305 ("Arbitrator decided to shutdown this node") to avoid split-brain, taking the node group offline until both replicas come back via system restart.

This race fired during the 0.7.29 -> 25.10.6 upgrade on content-visibility-test-infra (~2 min 33 s outage, no data lost).

Add a pre-upgrade hook that brings the MGMd StatefulSet to its target pod template (new image, new configIniHash, new config.ini) and waits for it to be Ready and serving (ndb_mgm -e show) before any other manifest in the chart is applied. Helm's main apply then sees no diff for MGMd, so MGMd is not rolled again and the rest of the StatefulSets roll against a stable primary arbitrator.

Generated with Claude Code