### PR TITLE
[RONDB-1057] Expose optional rondb config parameters (#176)

### DIFF
--- a/files/configs/config.ini
+++ b/files/configs/config.ini
@@ -92,6 +92,10 @@ TotalMemoryConfig={{ div $intermediateResult 100 }}M
 DiskPageBufferMemory={{ .Values.rondbConfig.DiskPageBufferMemory }}
 {{- end }}
 
+{{ if .Values.rondbConfig.MaxDiskWriteSpeed -}}
+MaxDiskWriteSpeed={{ .Values.rondbConfig.MaxDiskWriteSpeed }}
+{{- end }}
+
 {{ if .Values.rondbConfig.MaxNoOfTables -}}
 MaxNoOfTables={{ .Values.rondbConfig.MaxNoOfTables }}
 {{- end }}
@@ -102,6 +106,10 @@ MaxNoOfAttributes={{ .Values.rondbConfig.MaxNoOfAttributes }}
 
 {{ if .Values.rondbConfig.MaxNoOfTriggers -}}
 MaxNoOfTriggers={{ .Values.rondbConfig.MaxNoOfTriggers }}
+{{- end }}
+
+{{ if .Values.rondbConfig.MaxNoOfSchemaObjects -}}
+MaxNoOfSchemaObjects={{ .Values.rondbConfig.MaxNoOfSchemaObjects }}
 {{- end }}
 
 {{ if .Values.rondbConfig.TransactionMemory -}}
@@ -134,6 +142,26 @@ OsStaticOverhead={{ .Values.rondbConfig.OsStaticOverhead }}
 
 {{ if .Values.rondbConfig.OsCpuOverhead -}}
 OsCpuOverhead={{ .Values.rondbConfig.OsCpuOverhead }}
+{{- end }}
+
+{{ if .Values.rondbConfig.DataMemory -}}
+DataMemory={{ .Values.rondbConfig.DataMemory }}
+{{- end }}
+
+{{ if .Values.rondbConfig.LongMessageBuffer -}}
+LongMessageBuffer={{ .Values.rondbConfig.LongMessageBuffer }}
+{{- end }}
+
+{{ if .Values.rondbConfig.TimeBetweenGlobalCheckpoints -}}
+TimeBetweenGlobalCheckpoints={{ .Values.rondbConfig.TimeBetweenGlobalCheckpoints }}
+{{- end }}
+
+{{ if and (hasKey .Values.rondbConfig "UseOnlyIPv4") (not (eq .Values.rondbConfig.UseOnlyIPv4 nil)) -}}
+UseOnlyIPv4={{ .Values.rondbConfig.UseOnlyIPv4 }}
+{{- end }}
+
+{{ if and (hasKey .Values.rondbConfig "FullRestartLogs") (not (eq .Values.rondbConfig.FullRestartLogs nil)) -}}
+FullRestartLogs={{ .Values.rondbConfig.FullRestartLogs }}
 {{- end }}
 
 # Size of the REDO log is NoOfFragmentLogParts * NoOfFragmentLogFiles * FragmentLogFileSize
@@ -221,6 +249,10 @@ InitialLogFileGroup=name=lg_1;undo_buffer_size=128M;undo_log_0.log:{{ $.Values.r
 InitialTablespace=name=ts_1;extent_size=16M;ts_1_data_file_0.dat:{{ $initialTS }}G
 
 [MYSQLD DEFAULT]
+
+{{ if and (hasKey .Values.rondbConfig "UseOnlyIPv4") (not (eq .Values.rondbConfig.UseOnlyIPv4 nil)) -}}
+UseOnlyIPv4={{ .Values.rondbConfig.UseOnlyIPv4 }}
+{{- end }}
 
 [NDB_MGMD DEFAULT]
 # This is where the configuration database is stored

--- a/values.schema.json
+++ b/values.schema.json
@@ -1334,6 +1334,16 @@
                     ],
                     "default": null
                 },
+                "MaxNoOfSchemaObjects": {
+                    "type": [
+                        "integer",
+                        "null"
+                    ],
+                    "description": "Maximum total number of schema objects (tables, ordered indexes, unique hash indexes, etc.) that a data node may allocate. Increase this when the application needs more than the default cap of 20,320 table objects. Only applied if explicitly set; otherwise RonDB's built-in default is used. See https://docs.rondb.com/automatic_memory_config/.",
+                    "default": null,
+                    "minimum": 20320,
+                    "maximum": 200000
+                },
                 "TransactionMemory": {
                     "type": [
                         "string",
@@ -1445,6 +1455,15 @@
                     "description": "DiskPageBufferMemory are used by disk columns. This is the page cache that contains disk pages when they are in memory. By default it is not defined.",
                     "default": null
                 },
+                "MaxDiskWriteSpeed": {
+                    "type": [
+                        "string",
+                        "null"
+                    ],
+                    "description": "Maximum disk write speed (bytes/sec, total across all ldm threads) used by local checkpoints during normal operation, i.e. when no node is restarting. The adaptive algorithm may write more slowly than this ceiling based on CPU usage and REDO log IO lag, but will not exceed it. Only applied if explicitly set; otherwise RonDB's built-in default is used. See https://docs.rondb.com/rondb_advanced_fs_config/.",
+                    "default": null,
+                    "example": "20M"
+                },
                 "ActivateRateLimits": {
                     "type": "integer",
                     "description": "Activate rate limits handling",
@@ -1478,6 +1497,51 @@
                         "null"
                     ],
                     "description": "The total memory configured by RonDB datanode. By default it is not defined and memory is calculated automatically.",
+                    "default": null
+                },
+                "DataMemory": {
+                    "type": [
+                        "string",
+                        "null"
+                    ],
+                    "description": "Memory available for storing in-memory database records on each data node, in bytes (with optional binary SI suffix, e.g. '4G'). When unset, RonDB's AutomaticMemoryConfig sizes this from the container's memory; only set explicitly to override automatic sizing. Only applied if explicitly set.",
+                    "default": null,
+                    "example": "4G"
+                },
+                "LongMessageBuffer": {
+                    "type": [
+                        "string",
+                        "null"
+                    ],
+                    "description": "Internal buffer used for passing long messages within and between nodes, in bytes (with optional binary SI suffix). NDB's built-in default is 64M. Only applied if explicitly set.",
+                    "default": null,
+                    "example": "64M"
+                },
+                "TimeBetweenGlobalCheckpoints": {
+                    "type": [
+                        "integer",
+                        "null"
+                    ],
+                    "description": "Time in milliseconds between group commits of transactions to disk. RonDB's built-in default is 2000 ms. Only applied if explicitly set.",
+                    "default": null,
+                    "minimum": 20,
+                    "maximum": 32000,
+                    "example": 2000
+                },
+                "UseOnlyIPv4": {
+                    "type": [
+                        "boolean",
+                        "null"
+                    ],
+                    "description": "When true, restricts all RonDB cluster connections to IPv4 sockets only. Applied under both [NDBD DEFAULT] and [MYSQLD DEFAULT] so it covers data nodes, MySQLds (including binlog/replica appliers/DDL), RDRS, and other API clients. Introduced in RonDB 21.04.5 for Dolphin SuperSockets compatibility.",
+                    "default": null
+                },
+                "FullRestartLogs": {
+                    "type": [
+                        "boolean",
+                        "null"
+                    ],
+                    "description": "Enable full restart logs (RonDB-specific). RonDB's release-build default is false.",
                     "default": null
                 }
             },

--- a/values.yaml
+++ b/values.yaml
@@ -343,14 +343,19 @@ restoreFromBackup:
     serverSideEncryption: null
 rondbConfig:
   ActivateRateLimits: 0
+  DataMemory: null
   DiskPageBufferMemory: null
   EmptyApiSlots: 8
+  FullRestartLogs: null
   HeartbeatIntervalDbApi: 5000
   HeartbeatIntervalDbDb: 5000
   InitialTablespaceSizeGiB: -1
+  LongMessageBuffer: null
   MaxDMLOperationsPerTransaction: 32768
+  MaxDiskWriteSpeed: null
   MaxNoOfAttributes: null
   MaxNoOfConcurrentOperations: 65536
+  MaxNoOfSchemaObjects: null
   MaxNoOfTables: null
   MaxNoOfTriggers: null
   MySQLdSlotsPerNode: 4
@@ -363,10 +368,12 @@ rondbConfig:
   ReservedConcurrentOperations: null
   SchemaMemory: null
   SharedGlobalMemory: null
+  TimeBetweenGlobalCheckpoints: null
   TotalMemoryConfig: null
   TransactionDeadlockDetectionTimeout: 1500
   TransactionInactiveTimeout: 15000
   TransactionMemory: null
+  UseOnlyIPv4: null
 serviceAccountAnnotations: {}
 staticCpuManagerPolicy: false
 terminationGracePeriodSeconds: 60


### PR DESCRIPTION
* [RONDB-1057] Add MaxDiskWriteSpeed to rondbConfig

Expose MaxDiskWriteSpeed as an optional rondbConfig parameter so operators can cap LCP disk write throughput during normal operation without falling back to a custom config.ini. The value is only emitted when explicitly set; otherwise RonDB's built-in default applies.



* [RONDB-1057] Expose more rondbConfig parameters

Add optional rondbConfig knobs that previously required overriding the config.ini directly:
  - MaxNoOfSchemaObjects (raises the default ~20,300 table-object cap)
  - DataMemory (overrides AutomaticMemoryConfig sizing)
  - LongMessageBuffer
  - TimeBetweenGlobalCheckpoints
  - UseOnlyIPv4 (data-node scope only; emitted under [NDBD DEFAULT])
  - FullRestartLogs (RonDB-specific verbose restart logging)

Each value is only emitted when explicitly set; otherwise RonDB's built-in default applies.



* [RONDB-1057] Tighten schema validation and round-trip booleans

Address PR review feedback on the new rondbConfig knobs:

  * Add source-verified minimum/maximum bounds for MaxNoOfSchemaObjects (20320..4294967039) and TimeBetweenGlobalCheckpoints (20..32000), so values that RonDB would reject at startup are caught by helm at install time. Bounds confirmed identical across RonDB 24.10.18, 25.10-main, and 26.02.2 (chart's appVersion).

  * Make UseOnlyIPv4 and FullRestartLogs distinguish all three schema states (null/true/false) by switching their config.ini conditionals to the nil-aware idiom already used at templates/shared_templates/_helpers.tpl:463. Previously, explicit false was indistinguishable from null due to Go-template truthiness.

  * Update TimeBetweenGlobalCheckpoints description to cite RonDB's verified 2000 ms default.

  * Clarify MaxNoOfSchemaObjects (precise 20,320 cap) and UseOnlyIPv4 (parameter applies to data + API nodes; chart emits under [NDBD DEFAULT] only) descriptions.



* [RONDB-1057] Apply UseOnlyIPv4 to MySQLd and API nodes too

The flag was previously only emitted under [NDBD DEFAULT], which left mysqld, binlog servers, replica appliers, DDL mysqld, RDRS, and ClusterJ slots free to use IPv6 — defeating the purpose of an "IPv4-only" deployment toggle.

Also emit UseOnlyIPv4 under [MYSQLD DEFAULT], which serves as the default section for both [MYSQLD] and [API] per-node entries (NDB treats [MYSQLD DEFAULT] and [API DEFAULT] as the same default scope for API_TOKEN parameters). With this change, the single rondbConfig.UseOnlyIPv4 toggle now covers all node types involved in RonDB cluster traffic.



* [RONDB-1057] Decrease the maximum limit for MaxNoOfSchemaObjects

---------

[RONDB-1057]: https://hopsworks.atlassian.net/browse/RONDB-1057?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[RONDB-1057]: https://hopsworks.atlassian.net/browse/RONDB-1057?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[RONDB-1057]: https://hopsworks.atlassian.net/browse/RONDB-1057?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[RONDB-1057]: https://hopsworks.atlassian.net/browse/RONDB-1057?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ