### PR TITLE
[HWORKS-2766] Simplify PriorityClass creation logic

### DIFF
--- a/templates/priority_class.yaml
+++ b/templates/priority_class.yaml
@@ -4,10 +4,7 @@
 {{/*
     TODO: Add logic to share PriorityClass between multiple charts
 */}}
-{{ if .Values.priorityClass -}}
-{{- $existingPC := lookup "scheduling.k8s.io/v1" "PriorityClass" "" .Values.priorityClass -}}
-{{- $managedByHelm := and $existingPC (eq (index $existingPC.metadata.annotations "meta.helm.sh/release-name" | default "") .Release.Name) -}}
-{{- if or (not $existingPC) $managedByHelm }}
+{{ if and .Values.createPriorityClass .Values.priorityClass -}}
 apiVersion: scheduling.k8s.io/v1
 kind: PriorityClass
 metadata:
@@ -15,5 +12,4 @@ metadata:
 value: 1000000
 globalDefault: false
 description: "This priority class should be used for rondb service pods only."
-{{- end  }}
 {{- end }}

--- a/values.schema.json
+++ b/values.schema.json
@@ -50,6 +50,11 @@
             "type": "string",
             "default": "rondb-high-priority"
         },
+        "createPriorityClass": {
+            "type": "boolean",
+            "default": true,
+            "description": "Flag to disable the creation of PriorityClass in case it was created beforehand"
+        },
         "enableSecurityContext": {
             "type": "boolean",
             "default": true

--- a/values.yaml
+++ b/values.yaml
@@ -53,6 +53,7 @@ clusterSize:
   minNumMySQLServers: 1
   minNumRdrs: 1
   numNodeGroups: 1
+createPriorityClass: true
 enableSecurityContext: true
 globalReplication:
   clusterNumber: 1


### PR DESCRIPTION
Instead of doing a Helm lookup to decide whether we need to apply the PriorityClass or not, provide an attribute to explicitly create it or not.

https://hopsworks.atlassian.net/browse/HWORKS-2766