### PR TITLE
[RONDB-1059] Expose BackupLogBufferSize as a rondbConfig parameter (#…

### DIFF
--- a/files/configs/config.ini
+++ b/files/configs/config.ini
@@ -226,7 +226,7 @@ SpinMethod=StaticSpinning
 CompressedLCP=0
 CompressedBackup=1
 
-BackupLogBufferSize= 16M
+BackupLogBufferSize={{ .Values.rondbConfig.BackupLogBufferSize }}
 
 # The maximum size of the memory unit to use when allocating memory for tables
 MaxAllocate=32M

--- a/values.schema.json
+++ b/values.schema.json
@@ -1474,6 +1474,11 @@
                     "default": null,
                     "example": "20M"
                 },
+                "BackupLogBufferSize": {
+                    "type": "string",
+                    "description": "Buffer that records writes occurring during an online backup; the backup aborts if it fills. Default 16M; increase (e.g. 256M) for write-heavy clusters. See https://docs.rondb.com/rondb_backup/.",
+                    "default": "16M"
+                },
                 "ActivateRateLimits": {
                     "type": "integer",
                     "description": "Activate rate limits handling",

--- a/values.yaml
+++ b/values.yaml
@@ -343,6 +343,7 @@ restoreFromBackup:
     serverSideEncryption: null
 rondbConfig:
   ActivateRateLimits: 0
+  BackupLogBufferSize: 16M
   DataMemory: null
   DiskPageBufferMemory: null
   EmptyApiSlots: 8


### PR DESCRIPTION
…185)

Replace the hardcoded BackupLogBufferSize=16M in config.ini with a templated value sourced from rondbConfig.BackupLogBufferSize so operators can raise it (RonDB docs recommend e.g. 256M for write-heavy clusters) without overriding the config.ini. Default stays at 16M, matching RonDB's own default.