### PR TITLE
[RONDB-1069] Expose PartitionsPerNode as a rondbConfig parameter

### DIFF
--- a/Chart.yaml
+++ b/Chart.yaml
@@ -6,7 +6,7 @@ name: rondb
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 25.10.11
+version: 25.10.10
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.

--- a/Chart.yaml
+++ b/Chart.yaml
@@ -6,7 +6,7 @@ name: rondb
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 25.10.10
+version: 25.10.11
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.

--- a/files/configs/config.ini
+++ b/files/configs/config.ini
@@ -148,6 +148,10 @@ OsCpuOverhead={{ .Values.rondbConfig.OsCpuOverhead }}
 DataMemory={{ .Values.rondbConfig.DataMemory }}
 {{- end }}
 
+{{ if .Values.rondbConfig.PartitionsPerNode -}}
+PartitionsPerNode={{ .Values.rondbConfig.PartitionsPerNode }}
+{{- end }}
+
 {{ if .Values.rondbConfig.LongMessageBuffer -}}
 LongMessageBuffer={{ .Values.rondbConfig.LongMessageBuffer }}
 {{- end }}

--- a/values.schema.json
+++ b/values.schema.json
@@ -1485,6 +1485,14 @@
                     "description": "Buffer that records writes occurring during an online backup; the backup aborts if it fills. Default 16M; increase (e.g. 256M) for write-heavy clusters. See https://docs.rondb.com/rondb_backup/.",
                     "default": "16M"
                 },
+                "PartitionsPerNode": {
+                    "type": [
+                        "integer",
+                        "null"
+                    ],
+                    "description": "Number of partitions per data node used when creating new tables. When null, RonDB chooses based on AutomaticThreadConfig / NumCPUs (typically the number of LDM threads). Only affects tables created after the change; existing tables are not repartitioned.",
+                    "default": null
+                },
                 "ActivateRateLimits": {
                     "type": "integer",
                     "description": "Activate rate limits handling",

--- a/values.yaml
+++ b/values.yaml
@@ -364,6 +364,7 @@ rondbConfig:
   MySQLdSlotsPerNode: 4
   OsCpuOverhead: null
   OsStaticOverhead: null
+  PartitionsPerNode: null
   RdrsMetadataSlotsPerNode: 1
   RdrsSlotsPerNode: 1
   RedoBuffer: null


### PR DESCRIPTION
Add a templated PartitionsPerNode emitted in config.ini only when set in rondbConfig, so operators can override the number of partitions per data node for newly created tables without patching config.ini. Default is null, in which case RonDB picks based on AutomaticThreadConfig / NumCPUs (typically the LDM thread count). Existing tables are not repartitioned.