### PR TITLE
[HWORKS-2858] Configuration property for mysqld_exporter max number of connections

### DIFF
--- a/Chart.yaml
+++ b/Chart.yaml
@@ -6,7 +6,7 @@ name: rondb
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 26.2.10
+version: 26.2.11
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.

--- a/templates/mysqlds/mysqld_exporter.yaml
+++ b/templates/mysqlds/mysqld_exporter.yaml
@@ -40,6 +40,7 @@ spec:
         args:
           - --web.listen-address=:{{ .Values.meta.mysqld.exporter.metricsPort }}
           - --exporter.max-open-conns={{ .Values.mysql.exporter.maxOpenConnections }}
+          - --no-collect.slave_status
         ports:
           - containerPort: {{ .Values.meta.mysqld.exporter.metricsPort }}
             name: metrics-port

--- a/templates/mysqlds/mysqld_exporter.yaml
+++ b/templates/mysqlds/mysqld_exporter.yaml
@@ -2,6 +2,9 @@
 
 
 {{ if .Values.mysql.exporter.enabled }}
+{{- if gt (.Values.mysql.exporter.maxOpenConnections | int) (.Values.mysql.exporter.maxUserConnections | int) }}
+{{- fail (printf "mysql.exporter.maxOpenConnections (%d) must not exceed mysql.exporter.maxUserConnections (%d), otherwise scrapes will be throttled by the exporter user's MAX_USER_CONNECTIONS grant" (.Values.mysql.exporter.maxOpenConnections | int) (.Values.mysql.exporter.maxUserConnections | int)) }}
+{{- end }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -36,6 +39,7 @@ spec:
             memory: {{ .Values.resources.requests.memory.mysqldExportersMiB }}Mi
         args:
           - --web.listen-address=:{{ .Values.meta.mysqld.exporter.metricsPort }}
+          - --exporter.max-open-conns={{ .Values.mysql.exporter.maxOpenConnections }}
         ports:
           - containerPort: {{ .Values.meta.mysqld.exporter.metricsPort }}
             name: metrics-port

--- a/values.schema.json
+++ b/values.schema.json
@@ -936,6 +936,12 @@
                             "type": "string",
                             "default": "exporter"
                         },
+                        "maxOpenConnections": {
+                            "type": "integer",
+                            "description": "Maximum number of open connections to the database per scrape. 1 (default) serializes all collectors onto a single connection; higher values let independent collectors run concurrently but may incur higher load on the database. Should not exceed maxUserConnections.",
+                            "default": 1,
+                            "minimum": 1
+                        },
                         "maxUserConnections": {
                             "type": "integer",
                             "default": 3

--- a/values.yaml
+++ b/values.yaml
@@ -245,6 +245,7 @@ mysql:
   credentialsSecretName: mysql-passwords
   exporter:
     enabled: false
+    maxOpenConnections: 1
     maxUserConnections: 3
     username: exporter
   force2410UserGrantMigration: false


### PR DESCRIPTION
Expose configuration property for setting the maximum number of
connections mysqld_exporter will use. It must be less than or
equal to exporter.maxUserConnections

Disable collector slave_status as it is no longer supported.
The query has been renamed to SHOW REPLICA STATUS

Signed-off-by: Antonios Kouzoupis <antonios@hopsworks.ai>