### PR TITLE
Expose UseTcInRRGroup and MaxRRGroupSize as rondbConfig parameters

### DIFF
--- a/files/configs/config.ini
+++ b/files/configs/config.ini
@@ -152,6 +152,14 @@ DataMemory={{ .Values.rondbConfig.DataMemory }}
 PartitionsPerNode={{ .Values.rondbConfig.PartitionsPerNode }}
 {{- end }}
 
+{{ if and (hasKey .Values.rondbConfig "UseTcInRRGroup") (not (eq .Values.rondbConfig.UseTcInRRGroup nil)) -}}
+UseTcInRRGroup={{ .Values.rondbConfig.UseTcInRRGroup }}
+{{- end }}
+
+{{ if .Values.rondbConfig.MaxRRGroupSize -}}
+MaxRRGroupSize={{ .Values.rondbConfig.MaxRRGroupSize }}
+{{- end }}
+
 {{ if .Values.rondbConfig.LongMessageBuffer -}}
 LongMessageBuffer={{ .Values.rondbConfig.LongMessageBuffer }}
 {{- end }}

--- a/values.schema.json
+++ b/values.schema.json
@@ -1498,6 +1498,24 @@
                     "description": "Number of partitions per data node used when creating new tables. When null, RonDB chooses based on AutomaticThreadConfig / NumCPUs (typically the number of LDM threads). Only affects tables created after the change; existing tables are not repartitioned.",
                     "default": null
                 },
+                "UseTcInRRGroup": {
+                    "type": [
+                        "boolean",
+                        "null"
+                    ],
+                    "description": "When true, each recv thread distributes connections only to TC threads within the same Round Robin (RR) group; when false, it distributes them across all TC threads. RonDB default is true.",
+                    "default": null
+                },
+                "MaxRRGroupSize": {
+                    "type": [
+                        "integer",
+                        "null"
+                    ],
+                    "description": "Max size of a Round Robin (RR) group. RonDB default is 8; allowed range is 8 to 32.",
+                    "minimum": 8,
+                    "maximum": 32,
+                    "default": null
+                },
                 "ActivateRateLimits": {
                     "type": "integer",
                     "description": "Activate rate limits handling",

--- a/values.yaml
+++ b/values.yaml
@@ -364,6 +364,7 @@ rondbConfig:
   MaxNoOfSchemaObjects: null
   MaxNoOfTables: null
   MaxNoOfTriggers: null
+  MaxRRGroupSize: null
   MySQLdSlotsPerNode: 4
   OsCpuOverhead: null
   OsStaticOverhead: null
@@ -381,6 +382,7 @@ rondbConfig:
   TransactionInactiveTimeout: 15000
   TransactionMemory: null
   UseOnlyIPv4: null
+  UseTcInRRGroup: null
 serviceAccountAnnotations: {}
 skipMgmdPreUpgradeRollout: false
 staticCpuManagerPolicy: false


### PR DESCRIPTION
Add templated UseTcInRRGroup and MaxRRGroupSize emitted in config.ini only when set in rondbConfig, so operators can tune Round Robin (RR) group behavior without patching config.ini. Both default to null, in which case RonDB uses its built-in defaults (UseTcInRRGroup=true, MaxRRGroupSize=8). MaxRRGroupSize accepts 8 to 32 per RonDB's ConfigInfo bounds.